### PR TITLE
Allow configuration of boolean properties in nexus scheduled tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -214,14 +214,44 @@ nexus_backup_configure: false
 # Current limitation: can only be ran once a day
 nexus_backup_cron: "* 0 21 * * ?"  # See cron expression in nexus create task GUI
 
+# Scheduled tasks
+# Note: these are tasks you define by yourself (default: none)
+# If you used `nexus_backup_configure: true` above you will see a scheduled task for this
+# in your GUI which is not part of the below list
 nexus_scheduled_tasks: []
-#  example task to compact blobstore :
-#  - name: compact-blobstore
+#  #  Example task to compact blobstore :
+#  - name: compact-docker-blobstore
 #    cron: '0 0 22 * * ?'
 #    typeId: blobstore.compact
-#    task_alert_email: alerts@example.org # optional
+#    task_alert_email: alerts@example.org  # optional
 #    taskProperties:
-#      blobstoreName: 'default' # all task attributes are stored as strings by nexus internally
+#      blobstoreName: {{ nexus_blob_names.docker.blob }} # all task attributes are stored as strings by nexus internally
+#  #  Example task to purge maven snapshots
+#  - name: Purge-maven-snapshots
+#    cron: '0 50 23 * * ?'
+#    typeId: repository.maven.remove-snapshots
+#    task_alert_email: alerts@example.org  # optional
+#    taskProperties:
+#      repositoryName: "*"  # * for all repos. Change to a repository name if you only want a specific one
+#      minimumRetained: "2"
+#      snapshotRetentionDays: "2"
+#      gracePeriodInDays: "2"
+#    booleanTaskProperties:
+#      removeIfReleased: true
+#  #  Example task to purge unused docker manifest and images
+#  - name: Purge unused docker manifests and images
+#    cron: '0 55 23 * * ?'
+#    typeId: "repository.docker.gc"
+#    task_alert_email: alerts@example.org  # optional
+#    taskProperties:
+#      repositoryName: "*"  # * for all repos. Change to a repository name if you only want a specific one
+#  #  Example task to purge incomplete docker uploads
+#  - name: Purge incomplete docker uploads
+#    cron: '0 0 0 * * ?'
+#    typeId: "repository.docker.upload-purge"
+#    task_alert_email: alerts@example.org  # optional
+#    taskProperties:
+#      age: "24"
 
 _nexus_privilege_defaults:
   type: repository-view

--- a/files/groovy/create_task.groovy
+++ b/files/groovy/create_task.groovy
@@ -25,6 +25,8 @@ if (parsed_args.task_alert_email) {
     taskConfiguration.setAlertEmail(parsed_args.task_alert_email)
 }
 
+parsed_args.booleanTaskProperties.each { key, value -> taskConfiguration.setBoolean(key, Boolean.valueOf(value)) }
+
 Schedule schedule = taskScheduler.scheduleFactory.cron(new Date(), parsed_args.cron)
 
 taskScheduler.scheduleTask(taskConfiguration, schedule)

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -18,3 +18,17 @@
     nexus_repos_yum_proxy:
       - name: epel_centos_7_x86_64
         remote_url: http://download.fedoraproject.org/pub/epel/7/x86_64
+
+    nexus_scheduled_tasks:
+      #  Example task to purge maven snapshots
+      - name: Purge-maven-snapshots
+        cron: '0 50 23 * * ?'
+        typeId: repository.maven.remove-snapshots
+        task_alert_email: alerts@example.org  # optional
+        taskProperties:
+          repositoryName: "*"
+          minimumRetained: "2"
+          snapshotRetentionDays: "2"
+          gracePeriodInDays: "2"
+        booleanTaskProperties:
+          removeIfReleased: true


### PR DESCRIPTION
Task configuration only takes into account string properties. This PR allows to set boolean properties as well.