### PR TITLE
Attribute no_block for systemd is not available in ansible 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: python
 cache:
   pip: true
   directories:
-    - molecule/default/.molecule/nexus-downloads/
+    - molecule/.nexus-downloads/
 services:
   - docker
 install:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,19 +3,16 @@
   systemd:
     daemon-reload: yes
     name: nexus.service
-    no_block: yes
 
 - name: nexus-service-restart
   systemd:
     name: nexus.service
     state: restarted
-    no_block: yes
 
 - name: nexus-service-stop
   systemd:
     name: nexus.service
     state: stopped
-    no_block: yes
   when: nexus_systemd_service_file.stat.exists
 
 - name: wait-for-nexus
@@ -34,7 +31,6 @@
     name: "{{ httpd_package_name }}.service"
     state: reloaded
     enabled: yes
-    no_block: yes
 
 - name: wait-for-httpd
   wait_for:

--- a/molecule/.nexus-downloads/.gitignore
+++ b/molecule/.nexus-downloads/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -8,13 +8,8 @@
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_yml: "{{ lookup('file', molecule_file) | from_yaml }}"
-    molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
 
   tasks:
-
-    - name: include variables from tested playbook
-      include_vars:
-        file: "{{ molecule_ephemeral_directory }}/../../../defaults/main.yml"
 
     - name: Create molecule instance(s)
       docker_container:
@@ -30,21 +25,4 @@
         volumes: "{{ item.volumes | default(omit) }}"
         capabilities: "{{ item.capabilities | default(omit) }}"
         ports: "{{ item.ports | default(omit) }}"
-      with_items: "{{ molecule_yml.platforms }}"
-
-    - name: create a dir in {{ molecule_ephemeral_directory }} for nexus package download
-      file:
-        path: "{{ molecule_ephemeral_directory }}/nexus-downloads"
-        state: directory
-
-    - name: get the current nexus version
-      get_url:
-        url: "http://download.sonatype.com/nexus/3/{{ nexus_package }}"
-        dest: "{{ molecule_ephemeral_directory }}/nexus-downloads/{{ nexus_package }}"
-        force: no
-
-    - name: copy nexus package do default image location into images
-      shell: "docker cp \
-              {{ molecule_ephemeral_directory }}/nexus-downloads/{{ nexus_package }} \
-              {{ item.name }}:/tmp/{{ nexus_package }}"
       with_items: "{{ molecule_yml.platforms }}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -33,26 +33,27 @@ provisioner:
 
 scenario:
   name: default
-  create_sequence:
-    - create
   check_sequence:
     - destroy
     - create
+    - prepare
     - converge
     - check
     - destroy
   converge_sequence:
     - create
+    - prepare
     - converge
   test_sequence:
     - lint
     - destroy
     - syntax
     - create
+    - prepare
     - converge
     - idempotence
     - check
-    - verify
+    # - verify
     - destroy
 
 verifier:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,2 @@
+---
+- include: "../sync-nexus-package.yml"

--- a/molecule/selinux/molecule.yml
+++ b/molecule/selinux/molecule.yml
@@ -3,6 +3,8 @@ dependency:
   name: galaxy
 driver:
   name: vagrant
+  safe_files:
+    - nexus-downloads
   provider:
     name: virtualbox
 lint:

--- a/molecule/selinux/prepare.yml
+++ b/molecule/selinux/prepare.yml
@@ -29,3 +29,5 @@
           shell: a2enmod ssl rewrite proxy proxy_http headers
 
       when: ansible_os_family == 'Debian'
+
+- include: "../sync-nexus-package.yml"

--- a/molecule/sync-nexus-package.yml
+++ b/molecule/sync-nexus-package.yml
@@ -1,0 +1,45 @@
+---
+- name: "Prepare poststep 1/2: download nexus package locally"
+  hosts: localhost
+  vars:
+    molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
+    molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
+
+  tasks:
+
+    - name: include variables from tested playbook
+      include_vars:
+        file: "{{ molecule_scenario_directory }}/../../defaults/main.yml"
+
+    - name: Make sure we have a dir in molecule base path for nexus package download
+      # This one should exist from git checkout and is shared accross scenarios
+      file:
+        path: "{{ molecule_scenario_directory }}/../.nexus-downloads"
+        state: directory
+
+    - name: Symlink nexus download dir in scenario context
+      file:
+        path: "{{ molecule_ephemeral_directory }}/nexus-downloads"
+        src: "{{ molecule_scenario_directory }}/../.nexus-downloads"
+        state: link
+
+    - name: get the current nexus version
+      get_url:
+        url: "http://download.sonatype.com/nexus/3/{{ nexus_package }}"
+        dest: "{{ molecule_scenario_directory }}/../.nexus-downloads/{{ nexus_package }}"
+        force: no
+
+
+- name: "Prepare posttep 2/2: sync nexus package to instances"
+  hosts: all
+  vars:
+    molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
+  tasks:
+
+    - name: copy nexus package(s) do default image location into images
+      synchronize:
+        src: "{{ molecule_ephemeral_directory }}/nexus-downloads/"
+        dest: "/tmp/"
+        checksum: yes
+        times: no
+        perms: no


### PR DESCRIPTION
The role announces requirements for ansible>=2.2.

no_block attribute for systemd is only available for ansible 2.3 and above

Stick to the announced requirements.

This PR also refactored molecule test to gain time in local testing by sharing nexus downloads accros scenarios.