### PR TITLE
Apache needs AllowEncodedSlashes to download npm scoped packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.iml
 molecule/**/.molecule/
 molecule/**/__pycache__/
+molecule/**/.cache
+molecule/**/.pytest_cache

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -53,7 +53,7 @@ scenario:
     - converge
     - idempotence
     - check
-    # - verify
+    - verify
     - destroy
 
 verifier:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -18,7 +18,7 @@
     nexus_delete_default_repos: true
     nexus_delete_default_blobstore: true
 
-    nexus_blob_split: false
+    nexus_blob_split: true
 
     nexus_config_pypi: true
     nexus_config_docker: true
@@ -29,6 +29,17 @@
     nexus_config_nuget: true
     nexus_config_gitlfs: true
     nexus_config_yum: true
+
+    nexus_anonymous_access: true
+
+    nexus_repos_npm_hosted: []
+    nexus_repos_npm_group:
+      - name: npm-public
+        member_repos:
+          - npm-registry
+    nexus_repos_npm_proxy:
+      - name: npm-registry
+        remote_url: https://registry.npmjs.org/
 
     nexus_repos_yum_proxy:
       - name: epel_centos_7_x86_64

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -6,9 +6,19 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_hosts_file(host):
-    f = host.file('/etc/hosts')
+def test_npm_scoped_package_download(host):
+    test_package_url = \
+        "https://localhost/repository/npm-public/@angular%2fcore"
 
-    assert f.exists
-    assert f.user == 'root'
-    assert f.group == 'root'
+    get_url_options = \
+        "url='%s' dest='/tmp/testfile' force='yes' validate_certs='no'" \
+        % (test_package_url)
+
+    download = host.ansible(
+               "get_url",
+               get_url_options,
+               check=False
+               )
+
+    assert download["status_code"] == 200
+    assert download.state == file

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -21,4 +21,4 @@ def test_npm_scoped_package_download(host):
                )
 
     assert download["status_code"] == 200
-    assert download["state"] == file
+    assert download["state"] == 'file'

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -21,4 +21,4 @@ def test_npm_scoped_package_download(host):
                )
 
     assert download["status_code"] == 200
-    assert download.state == file
+    assert download["state"] == file

--- a/molecule/selinux/playbook.yml
+++ b/molecule/selinux/playbook.yml
@@ -13,4 +13,15 @@
     httpd_ssl_cert_file_location: "{{ default_cert }}"
     httpd_ssl_cert_key_location: "{{ default_key }}"
 
+    nexus_anonymous_access: true
+    nexus_config_npm: true
+    nexus_repos_npm_hosted: []
+    nexus_repos_npm_group:
+      - name: npm-public
+        member_repos:
+          - npm-registry
+    nexus_repos_npm_proxy:
+      - name: npm-registry
+        remote_url: https://registry.npmjs.org/
+
     nexus_backup_configure: true

--- a/templates/nexus-vhost.conf
+++ b/templates/nexus-vhost.conf
@@ -27,4 +27,9 @@
 
   ErrorLog /var/log/{{ httpd_package_name }}/{{ public_hostname }}_nexus_error.log
   CustomLog /var/log/{{ httpd_package_name }}/{{ public_hostname }}_nexus_access.log common
+
+  {% if nexus_config_npm -%}
+  # This is needed for npm scoped packages downloads
+  AllowEncodedSlashes On
+  {% endif -%}
 </VirtualHost>


### PR DESCRIPTION
This is a rework of original PR #54 with a simpler implementation and tests.