### PR TITLE
feat: Ldap allow use of dynamic group type to map groups as roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,28 @@ Example LDAP config for simple authentication (using a DSA account) + groups map
     ldap_group_subtree: false
 ```
 
+Example LDAP config for simple authentication (using a DSA account) + groups mapped as roles dynamically :
+
+```yaml
+    nexus_ldap_realm: true
+  - ldap_name: 'LDAP config with DSA'
+    ldap_protocol: 'ldaps'
+    ldap_hostname: 'annuaire.mycompany.com'
+    ldap_port: 636
+    ldap_auth: 'simple'
+    ldap_auth_username: 'cn=mynexus,ou=dsa,dc=mycompany,dc=net'
+    ldap_auth_password: "{{ vault_ldap_dsa_password }}" # better keep passwords in an ansible vault
+    ldap_search_base: 'dc=mycompany,dc=net'
+    ldap_user_base_dn: 'ou=users'
+    ldap_user_object_class: 'inetOrgPerson'
+    ldap_user_id_attribute: 'uid'
+    ldap_user_real_name_attribute: 'cn'
+    ldap_user_email_attribute: 'mail'
+    ldap_map_groups_as_roles: true
+    ldap_map_groups_as_roles_type: 'dynamic'
+    ldap_user_memberof_attribute: 'memberOf'
+```
+
 ### Privileges, roles and users
 ```yaml
     nexus_privileges:

--- a/files/groovy/setup_ldap.groovy
+++ b/files/groovy/setup_ldap.groovy
@@ -50,12 +50,17 @@ mapping.setUserRealNameAttribute(parsed_args.user_real_name_attribute)
 mapping.setEmailAddressAttribute(parsed_args.user_email_attribute)
 
 if (parsed_args.map_groups_as_roles) {
-    mapping.setLdapGroupsAsRoles(true)
-    mapping.setGroupBaseDn(parsed_args.group_base_dn)
-    mapping.setGroupObjectClass(parsed_args.group_object_class)
-    mapping.setGroupIdAttribute(parsed_args.group_id_attribute)
-    mapping.setGroupMemberAttribute(parsed_args.group_member_attribute)
-    mapping.setGroupMemberFormat(parsed_args.group_member_format)
+    if(parsed_args.map_groups_as_roles_type == "static"){
+        mapping.setLdapGroupsAsRoles(true)
+        mapping.setGroupBaseDn(parsed_args.group_base_dn)
+        mapping.setGroupObjectClass(parsed_args.group_object_class)
+        mapping.setGroupIdAttribute(parsed_args.group_id_attribute)
+        mapping.setGroupMemberAttribute(parsed_args.group_member_attribute)
+        mapping.setGroupMemberFormat(parsed_args.group_member_format)
+    } else if (parsed_args.map_groups_as_roles_type == "dynamic") {
+        mapping.setLdapGroupsAsRoles(true)
+        mapping.setUserMemberOfAttribute(parsed_args.user_memberof_attribute)
+    }
 }
 
 mapping.setUserSubtree(parsed_args.user_subtree)

--- a/tasks/setup_ldap_each.yml
+++ b/tasks/setup_ldap_each.yml
@@ -18,6 +18,8 @@
       user_real_name_attribute: "{{ item.ldap_user_real_name_attribute }}"
       user_email_attribute: "{{ item.ldap_user_email_attribute }}"
       map_groups_as_roles: "{{ item.ldap_map_groups_as_roles | default(false) }}"
+      map_groups_as_roles_type: "{{ item.ldap_map_groups_as_roles_type | default('static') }}"
+      user_memberof_attribute: "{{ item.ldap_user_memberof_attribute | default('memberOf') }}"
       group_base_dn: "{{ item.ldap_group_base_dn | default('ou=groups') }}"
       group_object_class: "{{ item.ldap_group_object_class | default('groupOfNames') }}"
       group_id_attribute: "{{ item.ldap_group_id_attribute | default('cn') }}"


### PR DESCRIPTION
Add the ability to chose between dynamic and static group as role mapping with LDAP auth.
Defaulted to static, so it should be backward compatible.
You have to specify `ldap_map_groups_as_roles_type: 'dynamic'` to activate it.
And you can specify which ldap attribute map the groups with `ldap_user_memberof_attribute: mymemberOf` (defaulted to memberOf)