### PR TITLE
Switch ubuntu docker test image to new path after renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ deactivate
 ```
 
 To speed up tests, molecule uses automated docker build images on docker hub:
-* https://hub.docker.com/r/thoteam/ansible-ubuntu16.04-apache-java/
+* https://hub.docker.com/r/thoteam/ansible-ubuntu16_04-apache-java/
 * https://hub.docker.com/r/thoteam/ansible-centos7-apache-java/
 
 #### Testing everything

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,7 +12,7 @@ lint:
 
 platforms:
   - name: ubuntu-16.04
-    image: thoteam/ansible-ubuntu16.04-apache-java
+    image: thoteam/ansible-ubuntu16_04-apache-java
     image_version: latest
     command: /lib/systemd/systemd
     privileged: true


### PR DESCRIPTION
For maintenance reasons (i.e. problems importing the docker project in my ide correctly), the github and docker hub repositories for unbunt test image have been renamed:
ansible-ubuntu16.04-apache-java => ansible-ubuntu16_04-apache-java