### PR TITLE
Rut Auth Header Capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,18 @@ nexus_npm_bearer_token_realm: false
 nexus_docker_bearer_token_realm: false  # required for docker anonymous access
 ```
 
+The Remote User Realm can also be enabled with 
+
+```yaml
+nexus_rut_auth_realm: true
+```
+
+and the header can be configured by defining
+
+```yaml
+nexus_rut_auth_header: "CUSTOM_HEADER"
+```
+
 ### Scheduled tasks
 ```yaml
     nexus_scheduled_tasks: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,7 @@ public_hostname: 'nexus.vm'
 nexus_nuget_api_key_realm: false
 nexus_npm_bearer_token_realm: false
 nexus_rut_auth_realm: false
+# nexus_rut_auth_header: "CUSTOM_HEADER"
 nexus_ldap_realm: false
 nexus_docker_bearer_token_realm: false
 

--- a/molecule/nexus_test_vars.yml
+++ b/molecule/nexus_test_vars.yml
@@ -25,6 +25,9 @@ nexus_config_yum: true
 
 nexus_anonymous_access: true
 
+nexus_rut_auth_realm: false
+nexus_rut_auth_header: "CUSTOM_RUT_HEADER"
+
 nexus_repos_npm_hosted: []
 nexus_repos_npm_group:
   - name: npm-public

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -208,6 +208,16 @@
       ldap_realm: "{{ nexus_ldap_realm }}"
       docker_bearer_token_realm: "{{ nexus_docker_bearer_token_realm }}"
 
+- name: Configure RUT Auth header
+  include: call_script.yml
+  vars:
+    script_name: setup_capability
+    args:
+      capability_typeId: "rutauth"
+      capability_properties:
+        httpHeader: "{{ nexus_rut_auth_header }}"
+  when: nexus_rut_auth_header is defined
+
 - include: call_script.yml
   vars:
     script_name: setup_email


### PR DESCRIPTION
Allows the Remote User Token auth realm to be configured by adding the capability with the httpHeader parameter.

This is a simple clean rebased rework of #68