### PR TITLE
Fix database restore path changed in nexus 3.11

### DIFF
--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -87,6 +87,16 @@
     nexus_rest_api_endpoint: "service/rest/v1/script"
   when: nexus_version is version_compare('3.8.0', '>=')
 
+- name: Get path to database restore dir (v < 3.11.0)
+  set_fact:
+    nexus_db_restore_dir: "{{ nexus_data_dir }}/backup"
+  when: nexus_version is version_compare('3.11.0', '<')
+
+- name: Get path to database restore dir (v >= 3.11.0)
+  set_fact:
+    nexus_db_restore_dir: "{{ nexus_data_dir }}/restore-from-backup"
+  when: nexus_version is version_compare('3.11.0', '>=')
+
 - name: Allow nexus to create first-time install configuration files in  {{ nexus_installation_dir }}/nexus-latest/etc
   file:
     path: "{{ item }}"

--- a/templates/nexus-blob-restore.sh.j2
+++ b/templates/nexus-blob-restore.sh.j2
@@ -13,6 +13,7 @@ MDATE=$1 ## Should be %Y-%m-%d-%H-%M-%S format
 blob_dir="blob-backup-${MDATE}"
 backup_dir={{ nexus_backup_dir }}
 data_dir={{ nexus_data_dir }}
+db_restore_dir={{ nexus_db_restore_dir }}
 blob_prefix={{ nexus_blob_prefix |d('blob-') }}
 
 systemctl stop nexus
@@ -23,6 +24,6 @@ if [ $return_status != 0 ]; then
 else
   rm -rf ${data_dir}/db/*
   rm -rf ${data_dir}/blobs/*
-  sudo -u {{ nexus_os_user }} cp ${backup_dir}/${blob_dir}/db/* ${data_dir}/backup/
+  sudo -u {{ nexus_os_user }} cp ${backup_dir}/${blob_dir}/db/* ${db_restore_dir}
   sudo -u {{ nexus_os_user }} cp -r ${backup_dir}/${blob_dir}/{${blob_prefix}*,default} ${data_dir}/blobs/
 fi


### PR DESCRIPTION
Restore directory for db changed name in nexus 3.11

<nexus_data_dir>/backup => <nexus_data_dir>/restore-from-backup