### PR TITLE
Add variable for specifying the Nexus package download URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,16 @@ Ansible variables, along with the default values (see `default/main.yml`) :
     nexus_version: '3.9.0-01'
     nexus_timezone: 'UTC'
     nexus_package: "nexus-{{ nexus_version }}-unix.tar.gz"
+    nexus_download_url: "http://download.sonatype.com/nexus/3"
 ```
 
 The nexus version and package to install, see available versions at https://www.sonatype.com/download-oss-sonatype .
+You may change the download site for packages by tuning `nexus_download_url` (e.g. closed environment, proxy/cache on your network...)
+
 `nexus_timezone` is a Java Timezone name and can be useful in combination with `nexus_scheduled_tasks` cron expressions below.
 
 Note that if you use a version version different from the default, you should make sure you do not use features which are not available for your version (e.g. yum hosted repositories for nexus < 3.8.0 or git lfs repo for nexus < 3.3.0)
+
 
 ### Download dir for nexus package
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 nexus_version: '3.9.0-01'
 nexus_package: "nexus-{{ nexus_version }}-unix.tar.gz"
 nexus_download_dir: '/tmp'
+nexus_download_url: 'http://download.sonatype.com/nexus/3'
 nexus_os_group: 'nexus'
 nexus_os_user: 'nexus'
 nexus_os_max_filedescriptors: 65536  # nexus > 3.5.x issues a warning on lower value. Next versions might not boot at all

--- a/molecule/sync-nexus-package.yml
+++ b/molecule/sync-nexus-package.yml
@@ -25,7 +25,7 @@
 
     - name: get the current nexus version
       get_url:
-        url: "http://download.sonatype.com/nexus/3/{{ nexus_package }}"
+        url: "{{ nexus_download_url }}/{{ nexus_package }}"
         dest: "{{ molecule_scenario_directory }}/../.nexus-downloads/{{ nexus_package }}"
         force: no
 

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -1,7 +1,7 @@
 ---
 - name: Download nexus_package
   get_url:
-    url: "http://download.sonatype.com/nexus/3/{{ nexus_package }}"
+    url: "{{ nexus_download_url }}/{{ nexus_package }}"
     dest: "{{ nexus_download_dir }}/{{ nexus_package }}"
     force: no
   notify:


### PR DESCRIPTION
By default, the default site is used. But now this can be overridden if needed (e.g. in closed environments).