### PR TITLE
WIP: Support the latest ansible version by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 services:
   - docker
 install:
-  - pip install -r requirements.txt
+  - pip install --upgrade --upgrade-strategy eager -r requirements.txt
 script:
   - ./tests/test_molecule.sh
 notifications:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@
 ## and produce unwanted errors.
 ##################################
 
-# Latest ansible 2.3.x
-ansible>=2.3,<2.4
+# Latest ansible
+ansible
 # Latest molecule
 molecule
 # Latest docker-py

--- a/tests/test_molecule.sh
+++ b/tests/test_molecule.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -ev
-molecule test
+molecule --debug test


### PR DESCRIPTION
From version 2.2, it has been decided the latest ansible version would be supported by default.