### PR TITLE
Install latest nexus version by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,19 +75,18 @@ Ansible variables, along with the default values (see `default/main.yml`) :
 
 ### General variables
 ```yaml
-    nexus_version: '3.12.0-01'
+    nexus_version: ''
     nexus_timezone: 'UTC'
-    nexus_package: "nexus-{{ nexus_version }}-unix.tar.gz"
     nexus_download_url: "http://download.sonatype.com/nexus/3"
 ```
 
-The nexus version and package to install, see available versions at https://www.sonatype.com/download-oss-sonatype .
-You may change the download site for packages by tuning `nexus_download_url` (e.g. closed environment, proxy/cache on your network...)
+The role will install/upgrade-to latest nexus available version by default. You may fix the version by tuning the `nexus_version` variable. See available versions at https://www.sonatype.com/download-oss-sonatype.
+
+If you use an older version of nexus, you should make sure you do not use features which are not available (e.g. yum hosted repositories for nexus < 3.8.0, git lfs repo for nexus < 3.3.0, etc.)
 
 `nexus_timezone` is a Java Timezone name and can be useful in combination with `nexus_scheduled_tasks` cron expressions below.
 
-Note that if you use a version version different from the default, you should make sure you do not use features which are not available for your version (e.g. yum hosted repositories for nexus < 3.8.0 or git lfs repo for nexus < 3.3.0)
-
+You may change the download site for packages by tuning `nexus_download_url` (e.g. closed environment, proxy/cache on your network...). **In this case, the automatic detection of the latest version will most likelly fail and you will have to set the version to download.** If you still want to take advantage of automatic latest version detection, a call to `<your_custom_location>/latest-unix.tar.gz` must return and HTTP 302 redirect to the latest available version in your cache/proxy.
 
 ### Download dir for nexus package
 ```yaml
@@ -559,7 +558,6 @@ Feel free to use them or implement your own install scenario at your convenience
   become: yes
 
   vars:
-    nexus_version: '3.7.1-02'
     nexus_timezone: 'Canada/Eastern'
     nexus_admin_password: "{{ vault_nexus_admin_password }}"
     httpd_server_name: 'nexus.vm'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
-nexus_version: '3.12.0-01'
-nexus_package: "nexus-{{ nexus_version }}-unix.tar.gz"
+nexus_version: ''
 nexus_download_dir: '/tmp'
 nexus_download_url: 'https://download.sonatype.com/nexus/3'
 nexus_os_group: 'nexus'

--- a/molecule/sync-nexus-package.yml
+++ b/molecule/sync-nexus-package.yml
@@ -25,8 +25,8 @@
 
     - name: get the current nexus version
       get_url:
-        url: "{{ nexus_download_url }}/{{ nexus_package }}"
-        dest: "{{ molecule_scenario_directory }}/../.nexus-downloads/{{ nexus_package }}"
+        url: "{{ nexus_download_url }}/latest-unix.tar.gz"
+        dest: "{{ molecule_scenario_directory }}/../.nexus-downloads/"
         force: no
 
 

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -9,6 +9,8 @@
         method: CONNECT
         status_code: 302
       register: nexus_latest_uri_call
+      # No changes made, we only need the target uri. Safe for check mode and needed for next operations
+      check_mode: no
 
     - name: Register latest nexus version from redirection
       set_fact:

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -1,4 +1,34 @@
 ---
+
+- name: No version given =>> calculate latest available nexus version
+  block:
+
+    - name: Call latest nexus uri to get redirection
+      uri:
+        url: "{{ nexus_download_url }}/latest-unix.tar.gz"
+        method: CONNECT
+        status_code: 302
+      register: nexus_latest_uri_call
+
+    - name: Register latest nexus version from redirection
+      set_fact:
+        nexus_version: "{{ nexus_latest_uri_call.location | regex_replace('^https://.*nexus-(\\d*\\.\\d*\\.\\d*-\\d*)-unix.tar.gz', '\\1') }}"
+
+  when: nexus_version == ''
+
+- name: Broken compatibility => nexus_package is now dynamically calculated
+  fail:
+    msg: >-
+      You have set the variable nexus_package in your playbook.
+      Starting from version 2.2.0 of this role, this is not compatible
+      with the new nexus latest version detection feature and is not
+      supported anymore. Please use the nexus_version variable only.
+  when: nexus_package is defined
+
+- name: Register nexus package name
+  set_fact:
+    nexus_package: "nexus-{{ nexus_version }}-unix.tar.gz"
+
 - name: Download nexus_package
   get_url:
     url: "{{ nexus_download_url }}/{{ nexus_package }}"

--- a/tasks/nexus_purge.yml
+++ b/tasks/nexus_purge.yml
@@ -8,13 +8,20 @@
 
 - meta: flush_handlers
 
+- name: get target path of current installed nexus version
+  command: 'readlink {{ nexus_installation_dir }}/nexus-latest'
+  register: nexus_readlink_latest_call
+  failed_when: false
+  changed_when: false
+  check_mode: no
+
 - name: "Purge Nexus"
   file:
     path: "{{ item }}"
     state: absent
   with_items:
     - "{{ nexus_data_dir }}"
-    - "{{ nexus_installation_dir }}/nexus-{{ nexus_version }}"
+    - "{{ nexus_readlink_latest_call.stdout | default(omit) }}"
     - "{{ nexus_restore_log }}"
     - "{{ nexus_installation_dir }}/nexus-latest"
     # - "{{ nexus_backup_dir }}" # Optional


### PR DESCRIPTION
Detect the latest available nexus by analyzing the redirect url
when calling https://download.sonatype.com/nexus/3/latest-unix.tar.gz

Fixes #76 