### PR TITLE
0077 umask hoses nexus user permissions

### DIFF
--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -40,7 +40,7 @@
   file:
     path: "{{ nexus_installation_dir }}/nexus-{{ nexus_version }}"
     recurse: yes
-    mode: "0755"
+    mode: "u=rwX,g=rX,o=rX"
 
 - name: Update symlink nexus-latest
   file:

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -39,8 +39,6 @@
 - name: Ensure proper ownership of nexus installation directory
   file:
     path: "{{ nexus_installation_dir }}/nexus-{{ nexus_version }}"
-    owner: "{{ nexus_os_user }}"
-    group: "{{ nexus_os_group }}"
     recurse: yes
     mode: "0755"
 

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -36,6 +36,14 @@
 
 - meta: flush_handlers
 
+- name: Ensure proper ownership of nexus installation directory
+  file:
+    path: "{{ nexus_installation_dir }}/nexus-{{ nexus_version }}"
+    owner: "{{ nexus_os_user }}"
+    group: "{{ nexus_os_group }}"
+    recurse: yes
+    mode: "0755"
+
 - name: Update symlink nexus-latest
   file:
     path: "{{ nexus_installation_dir }}/nexus-latest"


### PR DESCRIPTION
Recursively grant symbolic permissions 'u=rwX,g=rX,o=rX'  on installation directory so base images with restrictive umask values don't break assumptions regarding access.

Edit @zeitounator => Use symbolic perms rather than fixed ones. See https://github.com/ansible-ThoTeam/nexus3-oss/pull/90/commits/cda59f0b063f50169b1ab843385b8994a3635281

Edit @zeitounator => Waiting for a response from sonatype (https://issues.sonatype.org/browse/NEXUS-17893) which would fix the problem at source. Will merge if we do not get a positive outcome.