### PR TITLE
Fix Negative cache implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,10 +423,14 @@ Configuring blobstore on S3 is provided as a convenience and is not part of the 
         layout_policy: permissive
         # maximum_component_age: -1
         # maximum_metadata_age: 1440
+        # negative_cache_enabled: true
+        # negative_cache_ttl: 1440
       - name: jboss
         remote_url: 'https://repository.jboss.org/nexus/content/groups/public-jboss/'
         # maximum_component_age: -1
         # maximum_metadata_age: 1440
+        # negative_cache_enabled: true
+        # negative_cache_ttl: 1440
     # example with a login/password :
     # - name: secret-remote-repo
     #   remote_url: 'https://company.com/repo/secure/private/go/away'
@@ -434,6 +438,8 @@ Configuring blobstore on S3 is provided as a convenience and is not part of the 
     #   remote_password: 'secret'
     #   # maximum_component_age: -1
     #   # maximum_metadata_age: 1440
+    #   # negative_cache_enabled: true
+    #   # negative_cache_ttl: 1440
 ```
 
 Maven [proxy repositories](https://help.sonatype.com/display/NXRM3/Repository+Management#RepositoryManagement-ProxyRepository) configuration.
@@ -443,8 +449,6 @@ Maven [proxy repositories](https://help.sonatype.com/display/NXRM3/Repository+Ma
       - name: private-release
         version_policy: release
         write_policy: allow_once  # one of "allow", "allow_once" or "deny"
-        # negativeCacheEnabled: true
-        # timeToLive: 1440
 ```
 
 Maven [hosted repositories](https://help.sonatype.com/display/NXRM3/Repository+Management#RepositoryManagement-HostedRepository) configuration. Negative cache config is optionnal and will default to the above values if omitted.
@@ -470,6 +474,8 @@ All three repository types are combined with the following default values :
       write_policy: allow_once # one of "allow", "allow_once" or "deny"
       maximum_component_age: -1  # Nexus gui default. For proxies only
       maximum_metadata_age: 1440  # Nexus gui default. For proxies only
+      negative_cache_enabled: true # Nexus gui default. For proxies only
+      negative_cache_ttl: 1440 # Nexus gui default. For proxies only
 ```
 
 Docker, Pypi, Raw, Rubygems, Bower, NPM, Git-LFS and yum repository types:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -304,8 +304,8 @@ _nexus_repos_maven_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: -1  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
-  negative_cache_enabled: true # Nexus gui default. For proxies only
-  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
+  negative_cache_enabled: true  # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440  # Nexus gui default. For proxies only
 
 # pypi support ...
 _nexus_repos_pypi_defaults:
@@ -316,8 +316,8 @@ _nexus_repos_pypi_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: 1440  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
-  negative_cache_enabled: true # Nexus gui default. For proxies only
-  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
+  negative_cache_enabled: true  # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440  # Nexus gui default. For proxies only
 
 nexus_repos_pypi_hosted:
   - name: pypi-internal
@@ -348,8 +348,8 @@ _nexus_repos_raw_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: 1440  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
-  negative_cache_enabled: true # Nexus gui default. For proxies only
-  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
+  negative_cache_enabled: true  # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440  # Nexus gui default. For proxies only
 
 nexus_repos_raw_proxy:
   - name: ubuntu-archive
@@ -380,8 +380,8 @@ _nexus_repos_docker_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: 1440  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
-  negative_cache_enabled: true # Nexus gui default. For proxies only
-  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
+  negative_cache_enabled: true  # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440  # Nexus gui default. For proxies only
 
 nexus_repos_docker_hosted:
   - name: docker-hosted
@@ -415,8 +415,8 @@ _nexus_repos_rubygems_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: 1440  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
-  negative_cache_enabled: true # Nexus gui default. For proxies only
-  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
+  negative_cache_enabled: true  # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440  # Nexus gui default. For proxies only
 
 nexus_repos_rubygems_hosted:
   - name: rubygems-hosted
@@ -445,8 +445,8 @@ _nexus_repos_bower_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: 1440  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
-  negative_cache_enabled: true # Nexus gui default. For proxies only
-  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
+  negative_cache_enabled: true  # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440  # Nexus gui default. For proxies only
 
 nexus_repos_bower_hosted:
   - name: bower-internal
@@ -475,8 +475,8 @@ _nexus_repos_npm_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: 1440  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
-  negative_cache_enabled: true # Nexus gui default. For proxies only
-  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
+  negative_cache_enabled: true  # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440  # Nexus gui default. For proxies only
 
 nexus_repos_npm_hosted:
   - name: npm-internal
@@ -504,8 +504,8 @@ _nexus_repos_nuget_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: 1440  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
-  negative_cache_enabled: true # Nexus gui default. For proxies only
-  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
+  negative_cache_enabled: true  # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440  # Nexus gui default. For proxies only
 
 nexus_repos_nuget_hosted:
   - name: nuget-internal
@@ -557,5 +557,5 @@ _nexus_repos_yum_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: 1440  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
-  negative_cache_enabled: true # Nexus gui default. For proxies only
-  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
+  negative_cache_enabled: true  # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440  # Nexus gui default. For proxies only

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -221,10 +221,14 @@ nexus_repos_maven_proxy:
     layout_policy: permissive
     # maximum_component_age: -1
     # maximum_metadata_age: 1440
+    # negative_cache_enabled: true
+    # negative_cache_ttl: 1440
   - name: jboss
     remote_url: 'https://repository.jboss.org/nexus/content/groups/public-jboss/'
     # maximum_component_age: -1
     # maximum_metadata_age: 1440
+    # negative_cache_enabled: true
+    # negative_cache_ttl: 1440
 
 # example with a login/password :
 # - name: secret-remote-repo
@@ -233,6 +237,8 @@ nexus_repos_maven_proxy:
 #   remote_password: 'secret'
 #   # maximum_component_age: -1
 #   # maximum_metadata_age: 1440
+#   # negative_cache_enabled: true
+#   # negative_cache_ttl: 1440
 
 nexus_repos_maven_hosted:
   - name: private-release
@@ -298,6 +304,8 @@ _nexus_repos_maven_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: -1  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
+  negative_cache_enabled: true # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
 
 # pypi support ...
 _nexus_repos_pypi_defaults:
@@ -308,6 +316,8 @@ _nexus_repos_pypi_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: 1440  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
+  negative_cache_enabled: true # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
 
 nexus_repos_pypi_hosted:
   - name: pypi-internal
@@ -325,6 +335,8 @@ nexus_repos_pypi_proxy:
     remote_url: 'https://pypi.python.org/'
     # maximum_component_age: 1440
     # maximum_metadata_age: 1440
+    # negative_cache_enabled: true
+    # negative_cache_ttl: 1440
 
 # raw repo support
 
@@ -336,12 +348,16 @@ _nexus_repos_raw_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: 1440  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
+  negative_cache_enabled: true # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
 
 nexus_repos_raw_proxy:
   - name: ubuntu-archive
     remote_url: 'http://archive.ubuntu.com/ubuntu/'
     # maximum_component_age: 1440
     # maximum_metadata_age: 1440
+    # negative_cache_enabled: true
+    # negative_cache_ttl: 1440
 
 nexus_repos_raw_hosted:
   - name: raw-internal
@@ -364,6 +380,8 @@ _nexus_repos_docker_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: 1440  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
+  negative_cache_enabled: true # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
 
 nexus_repos_docker_hosted:
   - name: docker-hosted
@@ -379,6 +397,8 @@ nexus_repos_docker_proxy:
     use_nexus_certificates_to_access_index: false
     # maximum_component_age: 1440
     # maximum_metadata_age: 1440
+    # negative_cache_enabled: true
+    # negative_cache_ttl: 1440
 
 nexus_repos_docker_group:
   - name: docker-group
@@ -395,6 +415,8 @@ _nexus_repos_rubygems_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: 1440  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
+  negative_cache_enabled: true # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
 
 nexus_repos_rubygems_hosted:
   - name: rubygems-hosted
@@ -413,6 +435,8 @@ nexus_repos_rubygems_proxy:
     remote_url: https://rubygems.org
     # maximum_component_age: 1440
     # maximum_metadata_age: 1440
+    # negative_cache_enabled: true
+    # negative_cache_ttl: 1440
 
 # Bower support
 _nexus_repos_bower_defaults:
@@ -421,6 +445,8 @@ _nexus_repos_bower_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: 1440  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
+  negative_cache_enabled: true # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
 
 nexus_repos_bower_hosted:
   - name: bower-internal
@@ -439,6 +465,8 @@ nexus_repos_bower_proxy:
     remote_url: http://bower.herokuapp.com
     # maximum_component_age: 1440
     # maximum_metadata_age: 1440
+    # negative_cache_enabled: true
+    # negative_cache_ttl: 1440
 
 # npm support
 _nexus_repos_npm_defaults:
@@ -447,6 +475,8 @@ _nexus_repos_npm_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: 1440  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
+  negative_cache_enabled: true # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
 
 nexus_repos_npm_hosted:
   - name: npm-internal
@@ -465,6 +495,8 @@ nexus_repos_npm_proxy:
     remote_url: https://registry.npmjs.org
     # maximum_component_age: 1440
     # maximum_metadata_age: 1440
+    # negative_cache_enabled: true
+    # negative_cache_ttl: 1440
 
 _nexus_repos_nuget_defaults:
   blob_store: "{{ nexus_blob_names.nuget.blob }}"
@@ -472,6 +504,8 @@ _nexus_repos_nuget_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: 1440  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
+  negative_cache_enabled: true # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440 # Nexus gui default. For proxies only
 
 nexus_repos_nuget_hosted:
   - name: nuget-internal
@@ -490,6 +524,8 @@ nexus_repos_nuget_proxy:
     remote_url: http://www.nuget.org/api/v2
     # maximum_component_age: 1440
     # maximum_metadata_age: 1440
+    # negative_cache_enabled: true
+    # negative_cache_ttl: 1440
 
 # gitlfs support
 _nexus_repos_gitlfs_defaults:
@@ -509,6 +545,8 @@ nexus_repos_yum_proxy: []
 #   remote_url: http://download.fedoraproject.org/pub/epel/7/x86_64
 #   # maximum_component_age: 1440
 #   # maximum_metadata_age: 1440
+#   # negative_cache_enabled: true
+#   # negative_cache_ttl: 1440
 nexus_repos_yum_group: []
 
 _nexus_repos_yum_defaults:
@@ -519,3 +557,5 @@ _nexus_repos_yum_defaults:
   write_policy: allow_once  # one of "allow", "allow_once" or "deny"
   maximum_component_age: 1440  # Nexus gui default. For proxies only
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
+  negative_cache_enabled: true # Nexus gui default. For proxies only
+  negative_cache_ttl: 1440 # Nexus gui default. For proxies only

--- a/files/groovy/create_repo_bower_proxy.groovy
+++ b/files/groovy/create_repo_bower_proxy.groovy
@@ -48,8 +48,8 @@ if (existingRepository != null) {
                             strictContentTypeValidation: Boolean.valueOf(parsed_args.strict_content_validation)
                     ],
                     negativeCache: [
-                            enabled: parsed_args.get("negativeCacheEnabled", true),
-                            timeToLive: parsed_args.get("negativeCacheTTL", 1440.0)
+                            enabled: parsed_args.get("negative_cache_enabled", true),
+                            timeToLive: parsed_args.get("negative_cache_ttl", 1440.0)
                     ]
             ]
     )

--- a/files/groovy/create_repo_docker_proxy.groovy
+++ b/files/groovy/create_repo_docker_proxy.groovy
@@ -67,8 +67,8 @@ if (existingRepository != null) {
                             strictContentTypeValidation: Boolean.valueOf(parsed_args.strict_content_validation)
                     ],
                     negativeCache: [
-                        enabled: parsed_args.get("negativeCacheEnabled", true),
-                        timeToLive: parsed_args.get("negativeCacheTTL", 1440.0)
+                        enabled: parsed_args.get("negative_cache_enabled", true),
+                        timeToLive: parsed_args.get("negative_cache_ttl", 1440.0)
                     ]
             ]
     )

--- a/files/groovy/create_repo_maven_proxy.groovy
+++ b/files/groovy/create_repo_maven_proxy.groovy
@@ -54,8 +54,8 @@ if (existingRepository != null) {
                             strictContentTypeValidation: Boolean.valueOf(parsed_args.strict_content_validation)
                     ],
                     negativeCache: [
-                            enabled: parsed_args.get("negativeCacheEnabled", true),
-                            timeToLive: parsed_args.get("negativeCacheTTL", 1440.0)
+                            enabled: parsed_args.get("negative_cache_enabled", true),
+                            timeToLive: parsed_args.get("negative_cache_ttl", 1440.0)
                     ]
             ]
     )

--- a/files/groovy/create_repo_npm_proxy.groovy
+++ b/files/groovy/create_repo_npm_proxy.groovy
@@ -48,8 +48,8 @@ if (existingRepository != null) {
                             strictContentTypeValidation: Boolean.valueOf(parsed_args.strict_content_validation)
                     ],
                     negativeCache: [
-                            enabled: parsed_args.get("negativeCacheEnabled", true),
-                            timeToLive: parsed_args.get("negativeCacheTTL", 1440.0)
+                            enabled: parsed_args.get("negative_cache_enabled", true),
+                            timeToLive: parsed_args.get("negative_cache_ttl", 1440.0)
                     ]
             ]
     )

--- a/files/groovy/create_repo_nuget_proxy.groovy
+++ b/files/groovy/create_repo_nuget_proxy.groovy
@@ -49,8 +49,8 @@ if (existingRepository != null) {
                             strictContentTypeValidation: Boolean.valueOf(parsed_args.strict_content_validation)
                     ],
                     negativeCache: [
-                            enabled: parsed_args.get("negativeCacheEnabled", true),
-                            timeToLive: parsed_args.get("negativeCacheTTL", 1440.0)
+                            enabled: parsed_args.get("negative_cache_enabled", true),
+                            timeToLive: parsed_args.get("negative_cache_ttl", 1440.0)
                     ]
             ]
     )

--- a/files/groovy/create_repo_pypi_proxy.groovy
+++ b/files/groovy/create_repo_pypi_proxy.groovy
@@ -48,8 +48,8 @@ if (existingRepository != null) {
                             strictContentTypeValidation: Boolean.valueOf(parsed_args.strict_content_validation)
                     ],
                     negativeCache: [
-                            enabled: parsed_args.get("negativeCacheEnabled", true),
-                            timeToLive: parsed_args.get("negativeCacheTTL", 1440.0)
+                            enabled: parsed_args.get("negative_cache_enabled", true),
+                            timeToLive: parsed_args.get("negative_cache_ttl", 1440.0)
                     ]
             ]
     )

--- a/files/groovy/create_repo_raw_proxy.groovy
+++ b/files/groovy/create_repo_raw_proxy.groovy
@@ -48,8 +48,8 @@ if (existingRepository != null) {
                             strictContentTypeValidation: Boolean.valueOf(parsed_args.strict_content_validation)
                     ],
                     negativeCache: [
-                            enabled: parsed_args.get("negativeCacheEnabled", true),
-                            timeToLive: parsed_args.get("negativeCacheTTL", 1440.0)
+                            enabled: parsed_args.get("negative_cache_enabled", true),
+                            timeToLive: parsed_args.get("negative_cache_ttl", 1440.0)
                     ]
             ]
     )

--- a/files/groovy/create_repo_rubygems_proxy.groovy
+++ b/files/groovy/create_repo_rubygems_proxy.groovy
@@ -48,8 +48,8 @@ if (existingRepository != null) {
                             strictContentTypeValidation: Boolean.valueOf(parsed_args.strict_content_validation)
                     ],
                     negativeCache: [
-                            enabled: parsed_args.get("negativeCacheEnabled", true),
-                            timeToLive: parsed_args.get("negativeCacheTTL", 1440.0)
+                            enabled: parsed_args.get("negative_cache_enabled", true),
+                            timeToLive: parsed_args.get("negative_cache_ttl", 1440.0)
                     ]
             ]
     )

--- a/files/groovy/create_repo_yum_proxy.groovy
+++ b/files/groovy/create_repo_yum_proxy.groovy
@@ -48,8 +48,8 @@ if (existingRepository != null) {
                             strictContentTypeValidation: Boolean.valueOf(parsed_args.strict_content_validation)
                     ],
                     negativeCache: [
-                            enabled: parsed_args.get("negativeCacheEnabled", true),
-                            timeToLive: parsed_args.get("negativeCacheTTL", 1440.0)
+                            enabled: parsed_args.get("negative_cache_enabled", true),
+                            timeToLive: parsed_args.get("negative_cache_ttl", 1440.0)
                     ]
             ]
     )

--- a/molecule/nexus_test_vars.yml
+++ b/molecule/nexus_test_vars.yml
@@ -36,6 +36,7 @@ nexus_repos_npm_group:
 nexus_repos_npm_proxy:
   - name: npm-registry
     remote_url: https://registry.npmjs.org/
+    negative_cache_enabled: false
 
 nexus_repos_yum_hosted:
   - name: private_yum_centos_7
@@ -45,6 +46,7 @@ nexus_repos_yum_proxy:
     remote_url: http://download.fedoraproject.org/pub/epel/7/x86_64
     maximum_component_age: -1
     maximum_metadata_age: -1
+    negative_cache_ttl: 60
 nexus_repos_yum_group:
   - name: yum_all
     member_repos:


### PR DESCRIPTION
Negative cache implementation (#100) introduced some new variables which names don't respect the de facto coding standard (lower case with underscore separator).

Moreover, documentation and default vars were not updated correctly/accordingly.

This PR fixes those issues.