### PR TITLE
Allow to configure nexus auditing capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,13 @@ The fully qualified domain name under which the nexus instance will be accessibl
 
 Header and footer branding, those can contain HTML.
 
+### Audit capability
+```yaml
+    nexus_audit_enabled: false
+```
+
+The [Auditing capability of nexus](https://help.sonatype.com/repomanager3/security/auditing) is off by default. You can turn it on by switching this to `true`. Please note that the audit data is stored in nexus db, persits accross reboots and is not automatically rotated/cleared.
+
 ### Reverse proxy setup
 ```yaml
     httpd_setup_enable: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,6 +59,9 @@ nexus_rut_auth_realm: false
 nexus_ldap_realm: false
 nexus_docker_bearer_token_realm: false
 
+# Enable/disable audit capability
+nexus_audit_enabled: false
+
 # email server
 nexus_email_server_enabled: false
 nexus_email_server_host: "localhost"

--- a/files/groovy/setup_capability.groovy
+++ b/files/groovy/setup_capability.groovy
@@ -18,11 +18,11 @@ DefaultCapabilityReference existing = capabilityRegistry.all.find { CapabilityRe
 
 if (existing) {
     log.info(parsed_args.typeId + ' capability updated to: {}',
-            capabilityRegistry.update(existing.id(), existing.active, existing.notes(), parsed_args.capability_properties).toString()
+            capabilityRegistry.update(existing.id(), Boolean.valueOf(parsed_args.get('capability_enabled', true)), existing.notes(), parsed_args.capability_properties).toString()
     )
 }
 else {
     log.info(parsed_args.typeId + ' capability created as: {}', capabilityRegistry.
-            add(capabilityType, true, 'configured through api', parsed_args.capability_properties).toString()
+            add(capabilityType, Boolean.valueOf(parsed_args.get('capability_enabled', true)), 'configured through api', parsed_args.capability_properties).toString()
     )
 }

--- a/molecule/nexus_test_vars.yml
+++ b/molecule/nexus_test_vars.yml
@@ -25,6 +25,8 @@ nexus_config_yum: true
 
 nexus_anonymous_access: true
 
+nexus_audit_enabled: true
+
 nexus_rut_auth_realm: false
 nexus_rut_auth_header: "CUSTOM_RUT_HEADER"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -246,6 +246,7 @@
     script_name: setup_capability
     args:
       capability_typeId: "rapture.branding"
+      capability_enabled: "{{ nexus_branding_footer != '' and nexus_branding_header != '' }}"
       capability_properties:
         footerHtml: "{{ nexus_branding_footer }}"
         headerHtml: "{{ nexus_branding_header }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -254,6 +254,15 @@
         footerEnabled: "{{ nexus_branding_footer != '' }}"
         headerEnabled: "{{ nexus_branding_header != '' }}"
 
+- name: Configure audit capability
+  include_tasks: call_script.yml
+  vars:
+    script_name: setup_capability
+    args:
+      capability_typeId: "audit"
+      capability_enabled: "{{ nexus_audit_enabled | bool }}"
+      capability_properties: {}
+
 - include_tasks: create_task_each.yml
   with_items: "{{ nexus_scheduled_tasks }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -219,6 +219,7 @@
     script_name: setup_capability
     args:
       capability_typeId: "rutauth"
+      capability_enabled: true
       capability_properties:
         httpHeader: "{{ nexus_rut_auth_header }}"
   when: nexus_rut_auth_header is defined


### PR DESCRIPTION
Auditing capability is created by default but disabled. Allow to turn it on.

This requires a change to how capabilities are handled through groovy script files/groovy/setup_capability.groovy

Before: if capability exists, use its current value for "This capability is enabled"
After: if capability exists, enable it by default unless an arg `capability_enabled: false' is passed