### PR TITLE
Allow to force groovy scripts (re-)registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ _(Created with [gh-md-toc](https://github.com/ekalinin/github-markdown-toc))_
             * [Possible limitations](#possible-limitations)
          * [Special maintenance/debug variables](#special-maintenancedebug-variables)
             * [Purge nexus](#purge-nexus)
+            * [Force groovy scripts registration](#force-groovy-scripts-registration)
       * [Dependencies](#dependencies)
       * [Example Playbook](#example-playbook)
       * [Development, Contribution and Testing](#development-contribution-and-testing)
@@ -46,7 +47,7 @@ _(Created with [gh-md-toc](https://github.com/ekalinin/github-markdown-toc))_
       * [License](#license)
       * [Author Information](#author-information)
 
-<!-- Added by: olcla, at: 2018-09-11T11:07+02:00 -->
+<!-- Added by: olcla, at: 2018-09-11T11:37+02:00 -->
 
 <!--te-->
 
@@ -620,6 +621,23 @@ Use the `purge` variable if you need to restart from scratch and re-install a bl
 
 ```bash
 ansible-playbook -i your/inventory.ini your_nexus_playbook.yml -e purge=true
+```
+
+#### Force groovy scripts registration
+
+_This one is safe and will only make the playbook run longer if it wasn't needed_
+
+For performance sake, we use a little trick with several rsync to detect which maintenance groovy scripts need to be registered in Nexus. On some occasions (e.g. bad admin password, recovering a backup from a previous nexus instance with unregistered scripts...), this can lead to situation where the role will fail when attempting to run the needed groovy scripts.
+
+The symptom: you get HTTP 404 errors when the role tries to run scripts like in the following example (use `-v` option for ansible playbook):
+
+```bash
+fatal: [nexus3-oss]: FAILED! => {"changed": false, "connection": "close", "content": "", "date": "Tue, 11 Sep 2018 07:57:44 GMT", "msg": "Status code was 404 and not [200, 204]: HTTP Error 404: Not Found", "redirected": false, "server": "Nexus/3.13.0-01 (OSS)", "status": 404, "url": "http://localhost:8081/service/rest/v1/script/update_admin_password/run", "x_content_type_options": "nosniff", "x_siesta_faultid": "914acef2-f644-4bd6-9a7d-ce19255ea3dd"}
+```
+
+In such cases, you can force the (re-)registration of the groovy scripts with the `nexus_force_groovy_scripts_registration` variable:
+```yaml
+ansible-playbook -i your/inventory.ini your_playbook.yml -e nexus_force_groovy_scripts_registration=true
 ```
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ _(Created with [gh-md-toc](https://github.com/ekalinin/github-markdown-toc))_
          * [Backups](#backups)
             * [Restore procedure](#restore-procedure)
             * [Possible limitations](#possible-limitations)
+         * [Special maintenance/debug variables](#special-maintenancedebug-variables)
+            * [Purge nexus](#purge-nexus)
       * [Dependencies](#dependencies)
       * [Example Playbook](#example-playbook)
       * [Development, Contribution and Testing](#development-contribution-and-testing)
@@ -44,7 +46,7 @@ _(Created with [gh-md-toc](https://github.com/ekalinin/github-markdown-toc))_
       * [License](#license)
       * [Author Information](#author-information)
 
-<!-- Added by: olcla, at: 2018-09-10T16:10+02:00 -->
+<!-- Added by: olcla, at: 2018-09-11T11:07+02:00 -->
 
 <!--te-->
 
@@ -606,6 +608,19 @@ be used with caution and tested carefully on larger installations before moving
 to production. In any case, you are free to implement your own backup scenario
 outside of this role.
 
+### Special maintenance/debug variables
+
+These are not present in `defaults/main.yml` and are meant to be used on the command line only for maintenance/debug reasons.
+
+#### Purge nexus
+
+** Warning: this will completely erase the current data. Make sure to backup previously if needed **
+
+Use the `purge` variable if you need to restart from scratch and re-install a blank instance of nexus. 
+
+```bash
+ansible-playbook -i your/inventory.ini your_nexus_playbook.yml -e purge=true
+```
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -617,10 +617,10 @@ These are not present in `defaults/main.yml` and are meant to be used on the com
 
 ** Warning: this will completely erase the current data. Make sure to backup previously if needed **
 
-Use the `purge` variable if you need to restart from scratch and re-install a blank instance of nexus. 
+Use the `nexus_purge` variable if you need to restart from scratch and re-install a blank instance of nexus. 
 
 ```bash
-ansible-playbook -i your/inventory.ini your_nexus_playbook.yml -e purge=true
+ansible-playbook -i your/inventory.ini your_nexus_playbook.yml -e nexus_purge=true
 ```
 
 #### Force groovy scripts registration

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,7 +37,7 @@ nexus_backup_keep_rotations: 4  # Keep 4 backup rotation by default (current + l
 # nexus_restore_point: '2017-02-22-01-30-32' # Example format
 
 # Nexus purge procedure:
-# run ansible-playbook example.yml -e "purge=true"
+# run ansible-playbook example.yml -e "nexus_purge=true"
 
 # Nexus default properties
 nexus_default_port: 8081

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
   register: nexus_systemd_service_file
 
 - include_tasks: nexus_purge.yml
-  when: ((nexus_purge is defined) and (nexus_purge | bool))
+  when: nexus_purge | default(false) | bool
 
 - import_tasks: nexus_install.yml
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
   register: nexus_systemd_service_file
 
 - include_tasks: nexus_purge.yml
-  when: ((purge is defined) and (purge | bool))
+  when: ((nexus_purge is defined) and (nexus_purge | bool))
 
 - import_tasks: nexus_install.yml
 

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -346,6 +346,12 @@
   when: nexus_data_dir_contents.stdout != ""
   no_log: true
 
+- name: Force (re-)registration of groovy scripts (purge reference dir)
+  file:
+    path: "{{ nexus_data_dir }}/groovy-raw-scripts"
+    state: absent
+  when: nexus_force_groovy_scripts_registration | default(false)
+
 - name: Create directory to hold current groovy scripts for reference
   file:
     path: "{{ nexus_data_dir }}/groovy-raw-scripts/current"


### PR DESCRIPTION
This is a maintenance/debug command. Allow to force groovy resgistration with a special var (rather than having to manually delete the reference directory on target machine).

Took this opportunity to document this and also the purge procedure for nexus and renamed the variable for purge to follow var naming standards.

purge=true must now be nexus_purge=true