### PR TITLE
Allow to configure pre or post backup rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@ nexus_rut_auth_header: "CUSTOM_HEADER"
       nexus_backup_log: '{{ nexus_backup_dir }}/nexus-backup.log'
       nexus_restore_log: '{{ nexus_backup_dir }}/nexus-restore.log'
       nexus_backup_rotate: false
+      nexus_backup_rotate_first: false
       nexus_backup_keep_rotations: 4  # Keep 4 backup rotation by default (current + last 3)
 ```
 
@@ -595,10 +596,14 @@ declare in your playbook
 
 If you want to rotate backups, set `nexus_backup_rotate: true` and adjust
 the number of rotations you would like to keep with `nexus_backup_keep_rotations`
-(defaults to 4)
+(defaults to 4).
 
-Note that `nexus_backup_log` _must be writable_ by the nexus user or the **backup
-task will fail**
+When using rotation, if you want to save extra disk space during the backup process,
+you can set `nexus_backup_rotate_first: true`. This will configure a pre-rotation
+rather than the default post-rotation. Please note than in this case, old backup(s)
+is/are removed before the current one is done and successful.
+
+Note that `nexus_backup_log` _must be writable_ by the nexus user or the **backup task will fail**
 
 #### Restore procedure
 Run your playbook with parameter `-e nexus_restore_point=<YYYY-MM-dd-HH-mm-ss>`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,13 +24,11 @@ nexus_max_direct_memory: "2G"
 nexus_backup_dir: '/var/nexus-backup'
 nexus_restore_log: '{{ nexus_backup_dir }}/nexus-restore.log'
 nexus_backup_log: '{{ nexus_backup_dir }}/nexus-backup.log'
-# Shall we configure backup ?
-nexus_backup_configure: false
-# Backup time cron expression
+nexus_backup_configure: false  # Shall we configure backup ?
 nexus_backup_cron: "* 0 21 * * ?"  # See cron expression in nexus create task GUI
-# Shall we rotate backups ? No effect if nexus_backup_configure is false
-nexus_backup_rotate: false
-nexus_backup_keep_rotations: 4  # Keep 4 backup rotation by default (current + last 3)
+nexus_backup_rotate: false  # Shall we rotate backups
+nexus_backup_rotate_first: false  # Shall we rotate before making the current backup ?
+nexus_backup_keep_rotations: 4  # Keep 4 backup rotations by default (current + last 3)
 
 # Nexus restore procedure:
 # run ansible-playbook example.yml -e "nexus_restore_point=(# date of choice -> %Y-%m-%d-%H-%M-%S #)"

--- a/templates/backup.groovy.j2
+++ b/templates/backup.groovy.j2
@@ -11,13 +11,13 @@ import java.util.concurrent.TimeUnit
 /**
  * This groovy script is meant to be included in a schedulled task in nexus.
  * It will perform a full backup of your installation with the following steps.
- * 1- Create a blob-backup-<YY-MM-dd> folder in <nexusBackupDirPath> directory
+ * 1- If <nexusBackupRotate> and <nexusBackupRotateFirst> are true, pre-rotate backup dirs keeping last <nexusBackupKeepRotations-1> backups (making room for current backup)
  * 2- Create a temporary nexus db-backup task to store db backup in <nexusBackupDirPath>/blob-backup-<YY-MM-dd>/db
  * 3- Start running the temporary task
  * 4- Copy all blobstores from <nexusDataDirPath>/blobs to <nexusBackupDirPath>/blob-backup-<YY-MM-dd>
  * 5- Eventually wait for the nexus temporary db-backup task to complete
  * 6- Delete the nexus temporary db-backup task
- * 7- If <nexusBackupRotation> is true, rotate backup dirs keeping last <nexusBackupKeepRotations> backups
+ * 7- If <nexusBackupRotate> is true and <nexusBackupRotateFirst> is false, post-rotate backup dirs keeping last <nexusBackupKeepRotations> backups
  */
 
 
@@ -25,6 +25,7 @@ nexusBackupLogFilePath = "{{ nexus_backup_log }}"
 nexusBackupDirPath = "{{ nexus_backup_dir }}"
 nexusDataDirPath = "{{ nexus_data_dir }}"
 nexusBackupRotate = Boolean.valueOf("{{ nexus_backup_rotate }}")
+nexusBackupRotateFirst = Boolean.valueOf("{{ nexus_backup_rotate_first }}")
 nexusBackupKeepRotations = "{{ nexus_backup_keep_rotations }}".toInteger()
 
 backupDateString = LocalDateTime.now().format(DateTimeFormatter.ofPattern('YYYY-MM-dd-HH-mm-ss'))
@@ -35,8 +36,46 @@ backupLog = new File(nexusBackupLogFilePath)
 /** Clear log from previous backup */
 backupLog.text = ""
 
+/** Helper function to rotate backups */
+def rotateBackup() {
+    if (nexusBackupRotateFirst) {
+        realKeep = nexusBackupKeepRotations - 1
+        rotateMsg = "Pre-rotating"
+    } else {
+        realKeep = nexusBackupKeepRotations
+        rotateMsg = "Post-rotating"
+    }
+
+    backupLog << rotateMsg + " backups to keep only last "+nexusBackupKeepRotations.toString()+" Backups\n"
+    backupDirs = []
+    backupCounter = 0
+    backupPattern = ~/blob-backup-.*/
+    new File(nexusBackupDirPath).eachDirMatch(backupPattern) { dir ->
+        backupDirs << dir
+    }
+    backupDirs.sort{ it.name }.reverse().each { dir ->
+        backupCounter++
+        if (backupCounter > realKeep) {
+            backupLog << "Deleting backup "+ dir.name.toString() + "\n"
+            dir.deleteDir()
+        }
+    }
+    if (backupCounter > realKeep) {
+        backupDeleted =  backupCounter - realKeep
+        backupLog << "Deleted a total of "+ backupDeleted + " backup directories\n"
+    } else {
+        backupLog << "There where no backup directories to delete\n"
+    }
+}
+
 try {
     backupLog << "Backup directory is "+CurrentBackupDirPath+"\n"
+
+    /** pre backup rotation */
+    if (nexusBackupRotate && nexusBackupRotateFirst) {
+        rotateBackup()
+    }
+
     backupLog << "Create a temporary task to backup nexus db in "+CurrentBackupDirPath+"/db\n"
     TaskScheduler taskScheduler = container.lookup(TaskScheduler.class.getName())
     TaskConfiguration tempBackupTaskConfiguration = taskScheduler.createTaskConfigurationInstance('db.backup')
@@ -45,7 +84,7 @@ try {
     Schedule schedule = taskScheduler.scheduleFactory.manual()
     TaskInfo tempBackupTask = taskScheduler.scheduleTask(tempBackupTaskConfiguration, schedule)
 
-    backupLog << "Run the temporay db backup task\n"
+    backupLog << "Run the temporary db backup task\n"
     tempBackupTask.runNow()
 
     backupLog << "Copy the blobstores into "+CurrentBackupDirPath+"\n"
@@ -58,28 +97,11 @@ try {
     backupLog << "Remove temporary task\n"
     tempBackupTask.remove()
 
-    if (nexusBackupRotate) {
-        backupLog << "Rotating backups keeping last "+nexusBackupKeepRotations.toString()+" Backups\n"
-        backupDirs = []
-        backupCounter = 0
-        backupPattern = ~/blob-backup-.*/
-        new File(nexusBackupDirPath).eachDirMatch(backupPattern) { dir ->
-            backupDirs << dir
-        }
-        backupDirs.sort{ it.name }.reverse().each { dir ->
-            backupCounter++
-            if (backupCounter > nexusBackupKeepRotations) {
-                backupLog << "Deleting backup "+ dir.name.toString() + "\n"
-                dir.deleteDir()
-            }
-        }
-        if (backupCounter > nexusBackupKeepRotations) {
-            backupDeleted =  backupCounter - nexusBackupKeepRotations
-            backupLog << "Deleted a total of "+ backupDeleted + " backup directories\n"
-        } else {
-            backupLog << "There where no backup directories to delete\n"
-        }
+    /** Post backup rotation */
+    if (nexusBackupRotate && !nexusBackupRotateFirst) {
+        rotateBackup()
     }
+
 } catch (Exception e) {
     backupLog << e.toString()
 }


### PR DESCRIPTION
Backups where systematically rotated after current backup is performed.

This is still the default but you can now choose to rotate before performing current backup.