### PR TITLE
Disable sudo for local action

### DIFF
--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -417,6 +417,7 @@
     - "{{ nexus_data_dir }}/groovy-raw-scripts/new"
 
 - name: Archive scripts
+  become: no
   local_action:
     module: archive
     path: "{{ role_path }}/files/groovy/*"


### PR DESCRIPTION
Whatever the current settings are (global become activated or not) a local action does not require escalation privileges.