### PR TITLE
Avoid exception when trying to remove a repository that doesn't exist

### DIFF
--- a/files/groovy/delete_repo.groovy
+++ b/files/groovy/delete_repo.groovy
@@ -1,5 +1,31 @@
+/**
+ * Delete the repsotiroy of the name given in input if exist
+ *
+ * Input is json:
+ *   name: Repository name
+ * Output is json:
+ *   result: "true" if ok
+ *           "error message" if not ok
+ *           "null" if repository doesn't exist
+ *
+ **/
+
 import groovy.json.JsonSlurper
+import org.sonatype.nexus.repository.Repository
 
-parsed_args = new JsonSlurper().parseText(args)
+def arg = new JsonSlurper().parseText(args)
 
-repository.getRepositoryManager().delete(parsed_args.name)
+if(arg.name == null) {
+    return "you need to provid a repository 'name'"
+}
+Repository repo = repository.repositoryManager.get(arg.name)
+
+if (repo != null) {
+    try {
+        repository.repositoryManager.delete(repo.name)
+        repo.destroy()
+    } catch(Exception e) {
+        return e.toString()
+    }
+    return true
+}

--- a/files/groovy/delete_repo.groovy
+++ b/files/groovy/delete_repo.groovy
@@ -3,9 +3,6 @@ import org.sonatype.nexus.repository.Repository
 
 def arg = new JsonSlurper().parseText(args)
 
-if(arg.name == null) {
-    return "you need to provid a repository 'name'"
-}
 Repository repo = repository.repositoryManager.get(arg.name)
 
 if (repo != null) {

--- a/files/groovy/delete_repo.groovy
+++ b/files/groovy/delete_repo.groovy
@@ -1,9 +1,9 @@
 import groovy.json.JsonSlurper
 import org.sonatype.nexus.repository.Repository
 
-def arg = new JsonSlurper().parseText(args)
+def parsed_args = new JsonSlurper().parseText(args)
 
-Repository repo = repository.repositoryManager.get(arg.name)
+Repository repo = repository.repositoryManager.get(parsed_args.name)
 
 if (repo != null) {
     repository.repositoryManager.delete(repo.name)

--- a/files/groovy/delete_repo.groovy
+++ b/files/groovy/delete_repo.groovy
@@ -1,15 +1,3 @@
-/**
- * Delete the repsotiroy of the name given in input if exist
- *
- * Input is json:
- *   name: Repository name
- * Output is json:
- *   result: "true" if ok
- *           "error message" if not ok
- *           "null" if repository doesn't exist
- *
- **/
-
 import groovy.json.JsonSlurper
 import org.sonatype.nexus.repository.Repository
 
@@ -21,11 +9,6 @@ if(arg.name == null) {
 Repository repo = repository.repositoryManager.get(arg.name)
 
 if (repo != null) {
-    try {
-        repository.repositoryManager.delete(repo.name)
-        repo.destroy()
-    } catch(Exception e) {
-        return e.toString()
-    }
-    return true
+    repository.repositoryManager.delete(repo.name)
+    repo.destroy()
 }


### PR DESCRIPTION
Hello,

When we're trying to delete a repository that doesn't exist anymore an exception is raised by nexus, to avoid that I'm checking the repository exist before deleting it.

Also doing a destroy on the repository, I've seen some error in the UI only doing the delete.

Is it ok for you to integrate it ?

Regards,
