### PR TITLE
Use variable for nexus API url

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,7 +37,10 @@ nexus_backup_keep_rotations: 4  # Keep 4 backup rotations by default (current + 
 # run ansible-playbook example.yml -e "nexus_purge=true"
 
 # Nexus default properties
+nexus_default_schema: 'http'
+nexus_default_host: 'localhost'
 nexus_default_port: 8081
+nexus_validate_certs: yes
 nexus_docker_hosted_port: 9080
 nexus_docker_proxy_port: 9081
 nexus_docker_group_port: 9082

--- a/tasks/call_script.yml
+++ b/tasks/call_script.yml
@@ -1,7 +1,7 @@
 ---
 - name: Calling Groovy script {{ script_name }}
   uri:
-    url: "http://localhost:{{ nexus_default_port }}{{ nexus_default_context_path }}{{ nexus_rest_api_endpoint }}/{{ script_name }}/run"
+    url: "{{ nexus_default_schema }}://{{ nexus_default_host }}:{{ nexus_default_port }}{{ nexus_default_context_path }}{{ nexus_rest_api_endpoint }}/{{ script_name }}/run"
     user: 'admin'
     password: "{{ current_nexus_admin_password }}"
     headers:
@@ -9,4 +9,5 @@
     method: POST
     status_code: 200,204
     force_basic_auth: yes
+    validate_certs: "{{ nexus_validate_certs }}"
     body: "{{ args | to_json }}"

--- a/tasks/declare_script_each.yml
+++ b/tasks/declare_script_each.yml
@@ -1,21 +1,23 @@
 ---
 - name: Removing (potential) previously declared Groovy script {{ item }}
   uri:
-    url: "http://localhost:{{ nexus_default_port }}{{ nexus_default_context_path }}{{ nexus_rest_api_endpoint }}/{{ item }}"
+    url: "{{ nexus_default_schema }}://{{ nexus_default_host }}:{{ nexus_default_port }}{{ nexus_default_context_path }}{{ nexus_rest_api_endpoint }}/{{ item }}"
     user: 'admin'
     password: "{{ current_nexus_admin_password }}"
     method: DELETE
     force_basic_auth: yes
+    validate_certs: "{{ nexus_validate_certs }}"
     status_code: 204,404
 
 - name: Declaring Groovy script {{ item }}
   uri:
-    url: "http://localhost:{{ nexus_default_port }}{{ nexus_default_context_path }}{{ nexus_rest_api_endpoint }}"
+    url: "{{ nexus_default_schema }}://{{ nexus_default_host }}:{{ nexus_default_port }}{{ nexus_default_context_path }}{{ nexus_rest_api_endpoint }}"
     user: 'admin'
     password: "{{ current_nexus_admin_password }}"
     body_format: json
     method: POST
     force_basic_auth: yes
+    validate_certs: "{{ nexus_validate_certs }}"
     status_code: 204
     body:
       name: "{{ item }}"

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -358,11 +358,12 @@
 
 - name: Access scripts API endpoint with defined admin password
   uri:
-    url: "http://localhost:{{ nexus_default_port }}{{ nexus_default_context_path }}{{ nexus_rest_api_endpoint }}"
+    url: "{{ nexus_default_schema }}://{{ nexus_default_host }}:{{ nexus_default_port }}{{ nexus_default_context_path }}{{ nexus_rest_api_endpoint }}"
     method: 'HEAD'
     user: 'admin'
     password: "{{ nexus_admin_password }}"
     force_basic_auth: yes
+    validate_certs: "{{ nexus_validate_certs }}"
     status_code: 200, 401
   register: nexus_api_head_with_defined_password
   check_mode: no
@@ -375,11 +376,12 @@
 
 - name: Access scripts API endpoint with default admin password
   uri:
-    url: "http://localhost:{{ nexus_default_port }}{{ nexus_default_context_path }}{{ nexus_rest_api_endpoint }}"
+    url: "{{ nexus_default_schema }}://{{ nexus_default_host }}:{{ nexus_default_port }}{{ nexus_default_context_path }}{{ nexus_rest_api_endpoint }}"
     method: 'HEAD'
     user: 'admin'
     password: "{{ nexus_default_admin_password }}"
     force_basic_auth: yes
+    validate_certs: "{{ nexus_validate_certs }}"
     status_code: 200, 401
   register: nexus_api_head_with_default_password
   when: nexus_api_head_with_defined_password.status == 401


### PR DESCRIPTION
In some use case it can be usefull to change the API url. The default behavior to use http://localhost:8081 is not changed by default but it let the opportunity to change it if needed.

If SSL is used with self-signed certificate ssl check can be disabled.