### PR TITLE
Refactor cache parameters name in groovy scripts

### DIFF
--- a/files/groovy/create_repo_bower_proxy.groovy
+++ b/files/groovy/create_repo_bower_proxy.groovy
@@ -35,8 +35,8 @@ if (existingRepository != null) {
                     ],
                     proxy: [
                             remoteUrl: parsed_args.remote_url,
-                            contentMaxAge: parsed_args.get('content_max_age', 1440.0),
-                            metadataMaxAge: parsed_args.get('metadata_max_age', 1440.0)
+                            contentMaxAge: parsed_args.get('maximum_component_age', 1440.0),
+                            metadataMaxAge: parsed_args.get('maximum_metadata_age', 1440.0)
                     ],
                     httpclient: [
                             blocked: false,

--- a/files/groovy/create_repo_docker_proxy.groovy
+++ b/files/groovy/create_repo_docker_proxy.groovy
@@ -46,8 +46,8 @@ if (existingRepository != null) {
                     ],
                     proxy: [
                             remoteUrl: parsed_args.proxy_url,
-                            contentMaxAge: parsed_args.get('content_max_age', 1440.0),
-                            metadataMaxAge: parsed_args.get('metadata_max_age', 1440.0)
+                            contentMaxAge: parsed_args.get('maximum_component_age', 1440.0),
+                            metadataMaxAge: parsed_args.get('maximum_metadata_age', 1440.0)
                     ],
                     dockerProxy: [
                             indexType: parsed_args.index_type,

--- a/files/groovy/create_repo_maven_proxy.groovy
+++ b/files/groovy/create_repo_maven_proxy.groovy
@@ -38,8 +38,8 @@ if (existingRepository != null) {
                     ],
                     proxy  : [
                             remoteUrl: parsed_args.remote_url,
-                            contentMaxAge: parsed_args.get('content_max_age', -1),
-                            metadataMaxAge: parsed_args.get('metadata_max_age', 1440.0)
+                            contentMaxAge: parsed_args.get('maximum_component_age', -1),
+                            metadataMaxAge: parsed_args.get('maximum_metadata_age', 1440.0)
                     ],
                     httpclient: [
                             blocked: false,

--- a/files/groovy/create_repo_npm_proxy.groovy
+++ b/files/groovy/create_repo_npm_proxy.groovy
@@ -32,8 +32,8 @@ if (existingRepository != null) {
             attributes: [
                     proxy  : [
                             remoteUrl: parsed_args.remote_url,
-                            contentMaxAge: parsed_args.get('content_max_age', 1440.0),
-                            metadataMaxAge: parsed_args.get('metadata_max_age', 1440.0)
+                            contentMaxAge: parsed_args.get('maximum_component_age', 1440.0),
+                            metadataMaxAge: parsed_args.get('maximum_metadata_age', 1440.0)
                     ],
                     httpclient: [
                             blocked: false,

--- a/files/groovy/create_repo_nuget_proxy.groovy
+++ b/files/groovy/create_repo_nuget_proxy.groovy
@@ -33,8 +33,8 @@ if (existingRepository != null) {
             attributes: [
                     proxy  : [
                             remoteUrl: parsed_args.remote_url,
-                            contentMaxAge: parsed_args.get('content_max_age', 1440.0),
-                            metadataMaxAge: parsed_args.get('metadata_max_age', 1440.0)
+                            contentMaxAge: parsed_args.get('maximum_component_age', 1440.0),
+                            metadataMaxAge: parsed_args.get('maximum_metadata_age', 1440.0)
                     ],
                     httpclient: [
                             blocked: false,

--- a/files/groovy/create_repo_pypi_proxy.groovy
+++ b/files/groovy/create_repo_pypi_proxy.groovy
@@ -32,8 +32,8 @@ if (existingRepository != null) {
             attributes: [
                     proxy  : [
                             remoteUrl: parsed_args.remote_url,
-                            contentMaxAge: parsed_args.get('content_max_age', 1440.0),
-                            metadataMaxAge: parsed_args.get('metadata_max_age', 1440.0)
+                            contentMaxAge: parsed_args.get('maximum_component_age', 1440.0),
+                            metadataMaxAge: parsed_args.get('maximum_metadata_age', 1440.0)
                     ],
                     httpclient: [
                             blocked: false,

--- a/files/groovy/create_repo_raw_proxy.groovy
+++ b/files/groovy/create_repo_raw_proxy.groovy
@@ -32,8 +32,8 @@ if (existingRepository != null) {
             attributes: [
                     proxy  : [
                             remoteUrl: parsed_args.remote_url,
-                            contentMaxAge: parsed_args.get('content_max_age', 1440.0),
-                            metadataMaxAge: parsed_args.get('metadata_max_age', 1440.0)
+                            contentMaxAge: parsed_args.get('maximum_component_age', 1440.0),
+                            metadataMaxAge: parsed_args.get('maximum_metadata_age', 1440.0)
                     ],
                     httpclient: [
                             blocked: false,

--- a/files/groovy/create_repo_rubygems_proxy.groovy
+++ b/files/groovy/create_repo_rubygems_proxy.groovy
@@ -32,8 +32,8 @@ if (existingRepository != null) {
             attributes: [
                     proxy  : [
                             remoteUrl: parsed_args.remote_url,
-                            contentMaxAge: parsed_args.get('content_max_age', 1440.0),
-                            metadataMaxAge: parsed_args.get('metadata_max_age', 1440.0)
+                            contentMaxAge: parsed_args.get('maximum_component_age', 1440.0),
+                            metadataMaxAge: parsed_args.get('maximum_metadata_age', 1440.0)
                     ],
                     httpclient: [
                             blocked: false,

--- a/files/groovy/create_repo_yum_proxy.groovy
+++ b/files/groovy/create_repo_yum_proxy.groovy
@@ -32,8 +32,8 @@ if (existingRepository != null) {
             attributes: [
                     proxy  : [
                             remoteUrl: parsed_args.remote_url,
-                            contentMaxAge: parsed_args.get('content_max_age', 1440.0),
-                            metadataMaxAge: parsed_args.get('metadata_max_age', 1440.0)
+                            contentMaxAge: parsed_args.get('maximum_component_age', 1440.0),
+                            metadataMaxAge: parsed_args.get('maximum_metadata_age', 1440.0)
                     ],
                     httpclient: [
                             blocked: false,

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     </description>
 
     <properties>
-        <nx-version>3.12.0-01</nx-version>
+        <nx-version>3.15.2-01</nx-version>
     </properties>
 
     <build>


### PR DESCRIPTION
For some obscure reason, the parameters documented for proxy cache management where not aligned with the parameters examined in groovy scripts. So the default values where always used.

Renamed searched parameters for cache in proxies creation groovy to match the ones in documentation (and aligned to what is displayed in gui)