### PR TITLE
Added missing "type" property for the default nexus_privileges

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -177,6 +177,7 @@ nexus_privileges:
   - name: all-repos-read  # used as key to update a privilege
     description: 'Read & Browse access to all repos'
     repository: '*'
+    type: repository-view
     actions:
       - read
       - browse


### PR DESCRIPTION
If you do not override the default value of `nexus_privileges` and run the playbook you get the following result:

```
{
	"changed": false,
	"connection": "close",
	"content_length": "473",
	"content_type": "application/json",
	"cookies": {},
	"cookies_string": "",
	"date": "Tue, 26 Mar 2019 15:12:57 GMT",
	"json": {
		"name": "setup_privileges_from_list",
		"result": "{\"changed\":false,\"error\":true,\"action_details\":[{\"name\":\"all-repos-read\",\"status\":\"error\",\"debug\":\"test\",\"error_msg\":\"com.orientechnologies.orient.core.exception.OValidationException: The field 'privilege.type' cannot be null, record: privilege{id:all-repos-read,name:all-repos-read,description:Read & Browse access to all repos,type:null,properties:[7]}\\r\\n\\tDB name=\\\"security\\\"\"}]}"
	},
	"msg": "OK (473 bytes)",
	"redirected": false,
	"server": "Nexus/3.15.2-01 (OSS)",
	"status": 200,
	"url": "http://localhost:8081/service/rest/v1/script/setup_privileges_from_list/run",
	"x_content_type_options": "nosniff"
}
```

See the `error_msg` ?

>com.orientechnologies.orient.core.exception.OValidationException: The field 'privilege.type' cannot be null

By just adding the `type` attribute and setting it to `repository-view` it works fine.