### PR TITLE
Rework requirements.txt to fix ci builds failling (yamllint not found)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,10 +15,12 @@
 
 # Latest ansible
 ansible
-# Latest molecule from source
-git+https://github.com/ansible/molecule
-# Latest docker-py
-docker-py
+# Latest molecule
+molecule
+# Yamllint is not in molecule deps anymore
+yamllint
+# Latest docker
+docker
 # We use json_query in tasks which requires jmespath
 jmespath
 # Python vagrant only needed for local test for selinux


### PR DESCRIPTION
- Go back to stock molecule version on pypi now that
  development is back on tracks
- Add yamllint as it has been dropped from molecule deps
- Move to docker instead of docker-py which is deprecated