### PR TITLE
Privileges defaults are not applied and create privileges fails silently

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/files/groovy/create_repos_from_list.groovy
+++ b/files/groovy/create_repos_from_list.groovy
@@ -118,12 +118,18 @@ parsed_args.each { currentRepo ->
         if (existingRepository == null) {
             repositoryManager.create(configuration)
             currentResult.put('status', 'created')
+            scriptResults['changed'] = true
+            log.info('Configuration for repo {} created', currentRepo.name)
         } else {
-            repositoryManager.update(configuration)
-            currentResult.put('status', 'updated')
+            if (configuration.equals(existingRepository.configuration)) {
+                repositoryManager.update(configuration)
+                currentResult.put('status', 'updated')
+                log.info('Configuration for repo {} saved', currentRepo.name)
+                scriptResults['changed'] = true
+            } else {
+                currentResult.put('status', 'no change')
+            }
         }
-        log.info('Configuration for repo {} saved', currentRepo.name)
-        scriptResults['changed'] = true
 
     } catch (Exception e) {
         currentResult.put('status', 'error')

--- a/filter_plugins/nexus3_oss_filters.py
+++ b/filter_plugins/nexus3_oss_filters.py
@@ -1,0 +1,112 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleError, AnsibleFilterError
+import json
+
+class FilterModule(object):
+    """
+    nexus3-oss role filters
+    """
+    def filters(self):
+        return {
+            'nexus_groovy_error': self.nexus_groovy_error,
+            'nexus_groovy_changed': self.nexus_groovy_changed,
+            'nexus_groovy_details': self.nexus_groovy_details
+        }
+
+    def nexus_groovy_error(self, data):
+        """
+        Check if the passed uri module call data has returned an error
+
+        :param data: A registered var after calling the nexus groovy script though uri module
+        :return: boolean: true if error, false otherwise
+        """
+        return self._nexus_groovy_result(data, 'error')
+
+    def nexus_groovy_changed(self, data):
+        """
+        Check if the passed uri module call data has returned a changed state
+
+        :param data: A registered var after calling the nexus groovy script though uri module
+        :return: boolean: true if changed, false otherwise
+        """
+        return self._nexus_groovy_result(data, 'changed')
+
+    def nexus_groovy_details(self, data):
+        """
+        Returns the action_details part of the groovy call result if available or
+        some as relevant as possible info
+
+        :param data: A registered var after calling the nexus groovy script though uri module
+        :return: A list of maps for each action in the script if available or a string with the best relevant info
+        """
+        return self._nexus_groovy_result(data, 'action_details')
+
+    def _nexus_groovy_result(self, data, element):
+        """
+        Inspect data from an uri module call to a custom groovy script in nexus
+        and return the required element. This is based on a specific json
+        we return in result for groovy script in this role. If the result does
+        not contain the expected params or is not in json format, changed will always 
+        be false.
+        
+        The element can be:
+        - error: true if the call did not return a 200 status or error is true in result
+        - changed: true if changed is true in result
+        - details: a list of maps with details for each action taken in the script
+        
+        :param data: A registered var after calling the script though uri module
+        :param element: The desired element (error, changed, action_details)
+        :return: true/false or a list of maps with details.
+        """
+
+        valid_elements = ['error', 'changed', 'action_details']
+        if element not in valid_elements:
+            raise AnsibleFilterError("The element parameter must be one of {}".format(",".join(valid_elements)))
+
+        return self._get_script_run_results(data)[element]
+
+    def _get_script_run_results(self, data):
+
+        try:
+            request_status = data['status']
+        except KeyError:
+            raise AnsibleFilterError("The input data is not valid. It does not contain the key 'status'. "
+                                     "Is it a var registered from a uri: module call ?")
+
+        try:
+            json_data = data['json']
+        except KeyError:
+            raise AnsibleFilterError("The input data is not valid. It does not contain the key 'json'. "
+                                     "Is it a var registered from a uri: module call ?")
+
+        try:
+            raw_result = json_data['result']
+            if raw_result == "null":
+                raise KeyError
+        except KeyError:
+            raw_result = None
+
+        try:
+            result = json.loads(raw_result)
+            if result is None:
+                raise ValueError
+        except (ValueError, TypeError):
+            """This is not a result in json format or result key is absent"""
+            if request_status == 200:
+                result = {
+                    'error': False,
+                    'changed': False,
+                    'action_details': raw_result if raw_result else 'Script return in empty'
+                }
+            else:
+                result = {
+                    'error': True,
+                    'changed': False,
+                    'action_details': raw_result if raw_result else  "Global script failure"
+                }
+        except Exception as e:
+            raise AnsibleFilterError('Filter encountered an unexpected exception: {} {}'.format(type(e), e))
+
+        return result

--- a/filter_plugins/nexus3_oss_filters.py
+++ b/filter_plugins/nexus3_oss_filters.py
@@ -1,8 +1,9 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.errors import AnsibleError, AnsibleFilterError
+from ansible.errors import AnsibleFilterError
 import json
+
 
 class FilterModule(object):
     """
@@ -20,7 +21,7 @@ class FilterModule(object):
         Check if the passed uri module call data has returned an error
 
         :param data: A registered var after calling the nexus groovy script though uri module
-        :return: boolean: true if error, false otherwise
+        :return: boolean: True if error, False otherwise
         """
         return self._nexus_groovy_result(data, 'error')
 
@@ -29,7 +30,7 @@ class FilterModule(object):
         Check if the passed uri module call data has returned a changed state
 
         :param data: A registered var after calling the nexus groovy script though uri module
-        :return: boolean: true if changed, false otherwise
+        :return: boolean: True if changed, False otherwise
         """
         return self._nexus_groovy_result(data, 'changed')
 
@@ -48,17 +49,17 @@ class FilterModule(object):
         Inspect data from an uri module call to a custom groovy script in nexus
         and return the required element. This is based on a specific json
         we return in result for groovy script in this role. If the result does
-        not contain the expected params or is not in json format, changed will always 
-        be false.
-        
+        not contain the expected params or is not in json format, changed will always
+        be False.
+
         The element can be:
-        - error: true if the call did not return a 200 status or error is true in result
-        - changed: true if changed is true in result
+        - error: True if the call did not return a 200 status or error is True in result
+        - changed: True if changed is True in result
         - details: a list of maps with details for each action taken in the script
-        
+
         :param data: A registered var after calling the script though uri module
         :param element: The desired element (error, changed, action_details)
-        :return: true/false or a list of maps with details.
+        :return: True/False or a list of maps with details.
         """
 
         valid_elements = ['error', 'changed', 'action_details']
@@ -104,7 +105,7 @@ class FilterModule(object):
                 result = {
                     'error': True,
                     'changed': False,
-                    'action_details': raw_result if raw_result else  "Global script failure"
+                    'action_details': raw_result if raw_result else "Global script failure"
                 }
         except Exception as e:
             raise AnsibleFilterError('Filter encountered an unexpected exception: {} {}'.format(type(e), e))

--- a/tasks/call_script.yml
+++ b/tasks/call_script.yml
@@ -1,14 +1,48 @@
 ---
-- name: Calling Groovy script {{ script_name }}
-  uri:
-    url: "{{ nexus_api_scheme }}://{{ nexus_api_hostname }}:{{ nexus_api_port }}\
-      {{ nexus_api_context_path }}{{ nexus_rest_api_endpoint }}/{{ script_name }}/run"
-    user: 'admin'
-    password: "{{ current_nexus_admin_password }}"
-    headers:
-      Content-Type: "text/plain"
-    method: POST
-    status_code: 200,204
-    force_basic_auth: yes
-    validate_certs: "{{ nexus_api_validate_certs }}"
-    body: "{{ args | to_json }}"
+- block:
+    - name: Calling Groovy script {{ script_name }}
+      uri:
+        url: "{{ nexus_api_scheme }}://{{ nexus_api_hostname }}:{{ nexus_api_port }}\
+          {{ nexus_api_context_path }}{{ nexus_rest_api_endpoint }}/{{ script_name }}/run"
+        user: 'admin'
+        password: "{{ current_nexus_admin_password }}"
+        headers:
+          Content-Type: "text/plain"
+        method: POST
+        force_basic_auth: yes
+        validate_certs: "{{ nexus_api_validate_certs }}"
+        body: "{{ args | to_json }}"
+      register: script_run
+      failed_when: script_run | nexus_groovy_error | bool
+      changed_when: script_run | nexus_groovy_changed | bool
+
+    - name: Details about runned script if verbose mode is on
+      debug:
+        msg: "{{ script_run | nexus_groovy_details }}"
+        verbosity: 1
+
+  rescue:
+
+    - when: script_run | nexus_groovy_details == 'Global script failure'
+      block:
+
+        - name: Debug script result for global fail
+          debug:
+            var: script_run
+
+        - name: Global script failure at nexus level
+          fail:
+            msg: >-
+              Running the script {{ script_name }} failed at nexus level.
+              See the above debug output
+
+
+    - name: Debug script result for failed script actions
+      debug:
+        msg: "{{ script_run | nexus_groovy_details }}"
+
+    - name: Script action failure
+      fail:
+        msg: >-
+          The script {{ script_name }} returned at least one of its
+          actions has failed. See the degug message above for details

--- a/tasks/call_script.yml
+++ b/tasks/call_script.yml
@@ -20,6 +20,7 @@
       debug:
         msg: "{{ script_run | nexus_groovy_details }}"
         verbosity: 1
+      when: not ansible_check_mode
 
   rescue:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,6 +76,17 @@
     - include_tasks: create_content_selector_each.yml
       with_items: "{{ nexus_content_selectors }}"
 
+    - name: apply defaults to privileges
+      # @todo: fix with easier syntax once the flip filter is released
+      # See more comments on this issue in process_repos_list.yml
+      set_fact:
+        nexus_privileges: >-
+          {%- set result=[] -%}
+          {%- for privilege in nexus_privileges -%}
+            {{ result.append(_nexus_privilege_defaults | combine(privilege)) }}
+          {%- endfor -%}
+          {{ result | to_json | from_json }}
+
     - name: Create/check privileges
       include_tasks: call_script.yml
       vars:


### PR DESCRIPTION
This is an other implementation for #158.

Since groovy script refactoring has started, new scripts should now report the details of their execution. `tasks/call_script.yml` is not yet aware of these changes. This causes a situation where the script can report an error in its json return while the global http requests status still is 200, which will cause the error to be ignored silently. This is exactly what has been reported in #158.

This PR introduces a custom class with three filters able to check the script return and make the difference between old scripts (without details) and new ones (containing a json result with changed, error and details). For old script, only the http status is taken into account. For new scripts the detailed result is taken into account.

`tasks/call_script.yml` has been modified to use those filters and will now report changed/error/details for new refactored groovy scripts.

With this done, the privileges setup task was correctly failing and has been fixed by applying default value as before refactoring.