### PR TITLE
S3 blobstore creation fails with error `No such property: msg for class: Script5`

### DIFF
--- a/files/groovy/create_blobstores_from_list.groovy
+++ b/files/groovy/create_blobstores_from_list.groovy
@@ -31,11 +31,9 @@ parsed_args.each { blobstoreDef ->
             currentResult.put('error_msg', e.toString())
         }
     } else {
-        msg = "Blobstore {} already exists. Left untouched"
+        log.info("Blobstore {} already exists. Left untouched", blobstoreDef.name)
         currentResult.put('status', 'exists')
     }
-
-    log.info(msg, blobstoreDef.name)
 
     scriptResults['action_details'].add(currentResult)
 }


### PR DESCRIPTION
This is an implementation to fix #160.

The problem is in groovy script `files/groovy/create_blobstores_from_list.groovy`

When catching an exception on blobstore creation we do not define the var `msg` which is later used in a `log.info` function. This PR reworks `msg` definition and loging so that this error is not present anymore