### PR TITLE
Allow a task to be scheduled for manual or once (immediate) execution.

### DIFF
--- a/files/groovy/create_task.groovy
+++ b/files/groovy/create_task.groovy
@@ -29,6 +29,14 @@ if (parsed_args.task_alert_email) {
 
 parsed_args.booleanTaskProperties.each { key, value -> taskConfiguration.setBoolean(key, Boolean.valueOf(value)) }
 
-Schedule schedule = taskScheduler.scheduleFactory.cron(new Date(), parsed_args.cron)
+Schedule schedule = null;
+
+if (parsed_args.manual) {
+  schedule = taskScheduler.scheduleFactory.manual()
+} else if (parsed_args.once) {
+  schedule = taskScheduler.scheduleFactory.once(new Date())
+} else {
+  schedule = taskScheduler.scheduleFactory.cron(new Date(), parsed_args.cron)
+}
 
 taskScheduler.scheduleTask(taskConfiguration, schedule)

--- a/files/groovy/create_task.groovy
+++ b/files/groovy/create_task.groovy
@@ -31,12 +31,25 @@ parsed_args.booleanTaskProperties.each { key, value -> taskConfiguration.setBool
 
 Schedule schedule = null;
 
-if (parsed_args.manual) {
-  schedule = taskScheduler.scheduleFactory.manual()
-} else if (parsed_args.once) {
-  schedule = taskScheduler.scheduleFactory.once(new Date())
-} else {
-  schedule = taskScheduler.scheduleFactory.cron(new Date(), parsed_args.cron)
+switch( parsed_args.schedule_type ) {
+    case 'manual':
+        schedule = taskScheduler.scheduleFactory.manual()
+        break
+    case 'now':
+        schedule = taskScheduler.scheduleFactory.now()
+        break
+    case 'once':
+        schedule = taskScheduler.scheduleFactory.once(new Date())
+        break
+    case 'hourly':
+        schedule = taskScheduler.scheduleFactory.hourly(new Date())
+        break
+    case 'daily':
+        schedule = taskScheduler.scheduleFactory.daily(new Date())
+        break
+    default:
+        schedule = taskScheduler.scheduleFactory.cron(new Date(), parsed_args.cron)
+        break
 }
 
 taskScheduler.scheduleTask(taskConfiguration, schedule)

--- a/molecule/nexus_common_test_vars.yml
+++ b/molecule/nexus_common_test_vars.yml
@@ -68,22 +68,37 @@ nexus_scheduled_tasks:
       gracePeriodInDays: "2"
     booleanTaskProperties:
       removeIfReleased: true
-  #  Example task to run manually
+  #  Example task to run manually, now, once, daily, and hourly
   - name: Purge-unused-maven-snapshots-manual
-    manual: true
+    schedule_type: manual
     typeId: repository.maven.purge-unused-snapshots
-    task_alert_email: alerts@example.org  # optional
     taskProperties:
       repositoryName: "*"
-      lastUsedDays: "30"
-  #  Example task to run once
+      lastUsedDays: "1"
+  - name: Purge-unused-maven-snapshots-now
+    schedule_type: now
+    typeId: repository.maven.purge-unused-snapshots
+    taskProperties:
+      repositoryName: "*"
+      lastUsedDays: "2"
   - name: Purge-unused-maven-snapshots-once
-    once: true
+    schedule_type: once
     typeId: repository.maven.purge-unused-snapshots
-    task_alert_email: alerts@example.org  # optional
     taskProperties:
       repositoryName: "*"
-      lastUsedDays: "30"
+      lastUsedDays: "3"
+  - name: Purge-unused-maven-snapshots-daily
+    schedule_type: daily
+    typeId: repository.maven.purge-unused-snapshots
+    taskProperties:
+      repositoryName: "*"
+      lastUsedDays: "4"
+  - name: Purge-unused-maven-snapshots-hourly
+    schedule_type: hourly
+    typeId: repository.maven.purge-unused-snapshots
+    taskProperties:
+      repositoryName: "*"
+      lastUsedDays: "5"
 
 nexus_local_users:
   - username: jenkins

--- a/molecule/nexus_common_test_vars.yml
+++ b/molecule/nexus_common_test_vars.yml
@@ -68,6 +68,22 @@ nexus_scheduled_tasks:
       gracePeriodInDays: "2"
     booleanTaskProperties:
       removeIfReleased: true
+  #  Example task to run manually
+  - name: Purge-unused-maven-snapshots-manual
+    manual: true
+    typeId: repository.maven.purge-unused-snapshots
+    task_alert_email: alerts@example.org  # optional
+    taskProperties:
+      repositoryName: "*"
+      lastUsedDays: "30"
+  #  Example task to run once
+  - name: Purge-unused-maven-snapshots-once
+    once: true
+    typeId: repository.maven.purge-unused-snapshots
+    task_alert_email: alerts@example.org  # optional
+    taskProperties:
+      repositoryName: "*"
+      lastUsedDays: "30"
 
 nexus_local_users:
   - username: jenkins


### PR DESCRIPTION
- Adds logic to handle `manual`, `now`,  `once`, `daily`, and `hourly` [frequencies](https://help.sonatype.com/repomanager3/configuration/system-configuration#SystemConfiguration-ConfiguringandExecutingTasks) for scheduled tasks.
- Adds examples of each type of scheduled task in default molecule settings