### PR TITLE
Fix broken build with nexus 3.17

### DIFF
--- a/files/groovy/setup_users_from_list.groovy
+++ b/files/groovy/setup_users_from_list.groovy
@@ -10,7 +10,7 @@ import org.sonatype.nexus.security.user.User
 List<Map<String, String>> actionDetails = []
 @Field Map scriptResults = [changed: false, error: false]
 scriptResults.put('action_details', actionDetails)
-@Field authManager = security.securitySystem.getAuthorizationManager(UserManager.DEFAULT_SOURCE)
+authManager = security.securitySystem.getAuthorizationManager(UserManager.DEFAULT_SOURCE)
 
 def updateUser(userDef, currentResult) {
     User user = security.securitySystem.getUser(userDef.username)

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -392,6 +392,20 @@
   when: nexus_api_head_with_defined_password.status == 200
   no_log: true
 
+- name: Get generated admin password from file (nexus >= 3.17)
+  when:
+    - nexus_api_head_with_defined_password.status == 401
+    - nexus_version is version_compare('3.17.0', '>=')
+  block:
+    - name: Slurp content of remote generated password file
+      slurp:
+        src: "{{ nexus_data_dir }}/admin.password"
+      register: _slurpedpass
+
+    - name: Set default password from slurped content
+      set_fact:
+        nexus_default_admin_password: "{{ _slurpedpass.content | b64decode }}"
+
 - name: Access scripts API endpoint with default admin password
   uri:
     url: "{{ nexus_api_scheme }}://{{ nexus_api_hostname }}:{{ nexus_api_port }}\
@@ -414,7 +428,7 @@
   fail:
     msg: >-
       Failed to determine current Nexus password
-      (it is neither the default nor the defined password).
+      (it is neither the default/generated nor the defined password).
       If you are trying to change nexus_admin_password after first
       install, please set `-e nexus_default_admin_password=oldPassword`
       on the ansible-playbook command line.
@@ -487,5 +501,11 @@
       set_fact:
         current_nexus_admin_password: "{{ nexus_admin_password }}"
       no_log: true
+
+    - name: Clear generated password file from install (nexus > 3.17)
+      file:
+        path: "{{ nexus_data_dir }}/admin.password"
+        state: absent
+      when: nexus_version is version_compare('3.17.0', '>=')
 
   when: (nexus_api_head_with_default_password.status | default(false)) == 200


### PR DESCRIPTION
* Default admin password is now generated on first install and written to a file in nexus data dir. This breaks the admin password detection/change.
* An unnecessary `@Field` transform in script `setup_users_from_list.groovy` causes the script to Fail with the new version.

Fixes #174, #175 