### PR TITLE
Add the use_trust_store setting to ldap config

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Ldap connections and security realm are disabled by default
         ldap_protocol: 'ldaps' # ldap or ldaps
         ldap_hostname: 'ldap.mycompany.com'
         ldap_port: 636
+        ldap_use_trust_store: false # Wether or not to use certs in the nexus trust store
         ldap_search_base: 'dc=mycompany,dc=net'
         ldap_auth: 'none' # or simple
         ldap_auth_username: 'username' # if auth = simple
@@ -306,6 +307,7 @@ Example LDAP config for anonymous authentication (anonymous bind), this is also 
         ldap_hostname: 'annuaire.mycompany.com'
         ldap_search_base: 'dc=mycompany,dc=net'
         ldap_port: 636
+        ldap_use_trust_store: false
         ldap_user_id_attribute: 'uid'
         ldap_user_real_name_attribute: 'cn'
         ldap_user_email_attribute: 'mail'
@@ -321,6 +323,7 @@ Example LDAP config for simple authentication (using a DSA account) :
         ldap_protocol: 'ldaps'
         ldap_hostname: 'annuaire.mycompany.com'
         ldap_port: 636
+        ldap_use_trust_store: false
         ldap_auth: 'simple'
         ldap_auth_username: 'cn=mynexus,ou=dsa,dc=mycompany,dc=net'
         ldap_auth_password: "{{ vault_ldap_dsa_password }}" # better keep passwords in an ansible vault
@@ -342,6 +345,7 @@ Example LDAP config for simple authentication (using a DSA account) + groups map
         ldap_protocol: 'ldaps'
         ldap_hostname: 'annuaire.mycompany.com'
         ldap_port: 636
+        ldap_use_trust_store: false
         ldap_auth: 'simple'
         ldap_auth_username: 'cn=mynexus,ou=dsa,dc=mycompany,dc=net'
         ldap_auth_password: "{{ vault_ldap_dsa_password }}" # better keep passwords in an ansible vault
@@ -369,6 +373,7 @@ Example LDAP config for simple authentication (using a DSA account) + groups map
         ldap_protocol: 'ldaps'
         ldap_hostname: 'annuaire.mycompany.com'
         ldap_port: 636
+        ldap_use_trust_store: false
         ldap_auth: 'simple'
         ldap_auth_username: 'cn=mynexus,ou=dsa,dc=mycompany,dc=net'
         ldap_auth_password: "{{ vault_ldap_dsa_password }}" # better keep passwords in an ansible vault

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -124,6 +124,7 @@ ldap_connections: []
 #    ldap_protocol: 'ldaps' # ldap or ldaps
 #    ldap_hostname: 'ldap.mycompany.com'
 #    ldap_port: 636
+#    ldap_use_trust_store: false  # Wether or not to use certs in nexus trust store
 #    ldap_auth: 'simple' or 'none'
 #    ldap_auth_username: 'username' (or DN)   (optional)
 #    ldap_auth_password: 'password'           (optional)

--- a/files/groovy/setup_ldap.groovy
+++ b/files/groovy/setup_ldap.groovy
@@ -37,6 +37,7 @@ connection.setSearchBase(parsed_args.search_base)
 connection.setConnectionTimeout(30)
 connection.setConnectionRetryDelay(300)
 connection.setMaxIncidentsCount(3)
+connection.setUseTrustStore(Boolean.valueOf(parsed_args.use_trust_store))
 ldapConfig.setConnection(connection)
 
 

--- a/tasks/setup_ldap_each.yml
+++ b/tasks/setup_ldap_each.yml
@@ -7,6 +7,7 @@
       protocol: "{{ item.ldap_protocol }}"
       hostname: "{{ item.ldap_hostname }}"
       port: "{{ item.ldap_port }}"
+      use_trust_store: "{{ item.ldap_use_trust_store | default(false) | bool }}"
       auth: "{{ item.ldap_auth | default('none') }}"
       username: "{{ item.ldap_auth_username | default('') }}"
       password: "{{ item.ldap_auth_password | default('') }}"


### PR DESCRIPTION
Allow to define if ldap implementation should use the internal nexus trust store or not (default).
Fixes #178 