### PR TITLE
Update default RAM settings according to 2.18 release

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,9 +23,9 @@ nexus_script_dir: '{{ nexus_installation_dir }}/nexus-{{ nexus_version }}/etc/sc
 # https://help.sonatype.com/repomanager3/system-requirements#SystemRequirements-Memory
 # and you know what you are doing
 # Note: those values probably belong to a host_vars files...
-nexus_min_heap_size: "1200M"
+nexus_min_heap_size: "2703M"
 nexus_max_heap_size: "{{ nexus_min_heap_size }}"
-nexus_max_direct_memory: "2G"
+nexus_max_direct_memory: "{{ nexus_min_heap_size }}"
 
 # Nexus Backup
 nexus_backup_dir: '/var/nexus-backup'


### PR DESCRIPTION
Previous default settings:
Min Heap: 1200M
Max Heap: 1200M
Direct Memory: 2G

New defaults:
Min Heap: 2703M
Max Heap: 2703M
Direct Memory: 2703M

See https://issues.sonatype.org/browse/NEXUS-19954