### PR TITLE
Fix update condition for repositories

### DIFF
--- a/files/groovy/create_repos_from_list.groovy
+++ b/files/groovy/create_repos_from_list.groovy
@@ -121,7 +121,7 @@ parsed_args.each { currentRepo ->
             scriptResults['changed'] = true
             log.info('Configuration for repo {} created', currentRepo.name)
         } else {
-            if (configuration.equals(existingRepository.configuration)) {
+            if (!(configuration.properties == existingRepository.configuration.properties)) {
                 repositoryManager.update(configuration)
                 currentResult.put('status', 'updated')
                 log.info('Configuration for repo {} saved', currentRepo.name)


### PR DESCRIPTION
Repositories are not updated after creation on subsequent role run. This is due to a buggy condition checking if any configuration changed. See commit and changes for details.

Fixes #186