### PR TITLE
Add foreign layers support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -419,6 +419,9 @@ _nexus_repos_docker_defaults:
   maximum_metadata_age: 1440  # Nexus gui default. For proxies only
   negative_cache_enabled: true  # Nexus gui default. For proxies only
   negative_cache_ttl: 1440  # Nexus gui default. For proxies only
+  # More about Foreign Layers https://help.sonatype.com/repomanager3/formats/docker-registry/foreign-layers
+  cache_foreign_layers: false  # Nexus gui default. For proxies only
+  foreign_layer_url_whitelist: []  # Nexus gui default. For proxies only
 
 nexus_repos_docker_hosted:
   - name: docker-hosted
@@ -432,6 +435,10 @@ nexus_repos_docker_proxy:
     index_type: "HUB"
     remote_url: "https://registry-1.docker.io"
     use_nexus_certificates_to_access_index: false
+    # cache_foreign_layers: true
+    # foreign_layer_url_whitelist:
+    #   - "https?://go\\.microsoft\\.com/.*"
+    #   - "https://.*\\.azurecr\\.io/.*"
     # maximum_component_age: 1440
     # maximum_metadata_age: 1440
     # negative_cache_enabled: true

--- a/files/groovy/create_repos_from_list.groovy
+++ b/files/groovy/create_repos_from_list.groovy
@@ -94,7 +94,9 @@ parsed_args.each { currentRepo ->
         if (currentRepo.type == 'proxy' && currentRepo.format == 'docker') {
             configuration.attributes['dockerProxy'] = [
                     indexType                  : currentRepo.index_type,
-                    useTrustStoreForIndexAccess: currentRepo.use_nexus_certificates_to_access_index
+                    useTrustStoreForIndexAccess: currentRepo.use_nexus_certificates_to_access_index,
+                    foreignLayerUrlWhitelist   : currentRepo.foreign_layer_url_whitelist,
+                    cacheForeignLayers         : currentRepo.cache_foreign_layers
             ]
         }
 


### PR DESCRIPTION
Add [Foreign Layers](https://help.sonatype.com/repomanager3/formats/docker-registry/foreign-layers) support for docker-proxy repos in Nexus 3.19.

Fixes #195