### PR TITLE
Configure application-host without requiring Apache httpd.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,7 @@ nexus_docker_hosted_port: 9080
 nexus_docker_proxy_port: 9081
 nexus_docker_group_port: 9082
 nexus_default_context_path: '/'
+nexus_application_host: '{{ httpd_setup_enable | ternary("127.0.0.1", "0.0.0.0") }'
 
 # Nexus default admin password on first time install.
 # This should not be set in your playbook.

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -297,8 +297,7 @@
   lineinfile:
     dest: "{{ nexus_default_settings_file }}"
     regexp: "^application-host=.*"
-    line: "application-host=127.0.0.1"
-  when: httpd_setup_enable | bool
+    line: "application-host={{ nexus_application_host }}"
   notify:
     - nexus-service-stop
 


### PR DESCRIPTION
I need to deploy to an existing host with an existing, already-managed HTTP proxy. This small change allows setting an alternate listen without the role trying to manage httpd.