### PR TITLE
Create privileges, roles, and users after repos

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,34 +87,6 @@
           {%- endfor -%}
           {{ result | to_json | from_json }}
 
-    - name: Create/check privileges
-      include_tasks: call_script.yml
-      vars:
-        script_name: setup_privileges_from_list
-        args: "{{ nexus_privileges }}"
-      when: nexus_privileges | length > 0
-
-    - name: Create/check roles
-      include_tasks: call_script.yml
-      vars:
-        script_name: setup_roles_from_list
-        args: "{{ nexus_roles }}"
-      when: nexus_roles | length > 0
-
-    - name: Create/check local users
-      include_tasks: call_script.yml
-      vars:
-        script_name: setup_users_from_list
-        args: "{{ nexus_local_users }}"
-      when: nexus_local_users | length > 0
-
-    - name: Create/check ldap users
-      include_tasks: call_script.yml
-      vars:
-        script_name: setup_ldap_users_from_list
-        args: "{{ nexus_ldap_users }}"
-      when: nexus_ldap_users | length > 0
-
     - name: "Digest splited blob list var"
       include_vars: blob_vars.yml
       when: nexus_blob_split | bool
@@ -157,6 +129,34 @@
       vars:
         script_name: create_repos_from_list
         args: "{{ _nexus_repos_global_list }}"
+
+    - name: Create/check privileges
+      include_tasks: call_script.yml
+      vars:
+        script_name: setup_privileges_from_list
+        args: "{{ nexus_privileges }}"
+      when: nexus_privileges | length > 0
+
+    - name: Create/check roles
+      include_tasks: call_script.yml
+      vars:
+        script_name: setup_roles_from_list
+        args: "{{ nexus_roles }}"
+      when: nexus_roles | length > 0
+
+    - name: Create/check local users
+      include_tasks: call_script.yml
+      vars:
+        script_name: setup_users_from_list
+        args: "{{ nexus_local_users }}"
+      when: nexus_local_users | length > 0
+
+    - name: Create/check ldap users
+      include_tasks: call_script.yml
+      vars:
+        script_name: setup_ldap_users_from_list
+        args: "{{ nexus_ldap_users }}"
+      when: nexus_ldap_users | length > 0
 
   when: nexus_run_provisionning | default(true) | bool
 


### PR DESCRIPTION
While creating repository Nexus creates also a set of corresponding privileges
like `nx-repository-{admin|view}-<type>-<name>-<action>`, but one can't use
this priveleges for roles and users, because users are created earlier than
repos.

This patch changes order of actions creating roles/users and repos.