### PR TITLE
Create privileges, users and roles after repos

### DIFF
--- a/molecule/nexus_common_test_vars.yml
+++ b/molecule/nexus_common_test_vars.yml
@@ -118,7 +118,12 @@ nexus_roles:
     privileges:
       - 'nx-repository-view-yum-private_yum_centos_7-read'
       - 'nx-repository-view-yum-private_yum_centos_7-browse'
-
+  - name: developers
+    id: developers
+    description: "Developers"
+    privileges:
+      - all-repos-read
+      - wildcard1
 
 # proxy configuration depending on env
 nexus_with_http_proxy: "{{ lookup('env', 'http_proxy') | length > 0 | bool }}"

--- a/molecule/nexus_common_test_vars.yml
+++ b/molecule/nexus_common_test_vars.yml
@@ -79,6 +79,13 @@ nexus_local_users:
       - developers
   - username: olduser  # make sure this old account is removed
     state: absent
+  - username: test_roles
+    first_name: Test
+    last_name: Roles
+    email: test@roles.com
+    password: "s3cr3t"
+    roles:
+      - c-ro-private_yum_centos_7
 
 nexus_privileges:
   - name: all-repos-read
@@ -103,6 +110,15 @@ nexus_privileges:
     script_name: the_script_name
     actions:
       - some actions
+
+nexus_roles:
+  - name: c-ro-private_yum_centos_7
+    id: c-ro-private_yum_centos_7
+    description: "Custrom read-only role for private_yum_centos_7 hosted repository"
+    privileges:
+      - 'nx-repository-view-yum-private_yum_centos_7-read'
+      - 'nx-repository-view-yum-private_yum_centos_7-browse'
+
 
 # proxy configuration depending on env
 nexus_with_http_proxy: "{{ lookup('env', 'http_proxy') | length > 0 | bool }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,34 +87,6 @@
           {%- endfor -%}
           {{ result | to_json | from_json }}
 
-    - name: Create/check privileges
-      include_tasks: call_script.yml
-      vars:
-        script_name: setup_privileges_from_list
-        args: "{{ nexus_privileges }}"
-      when: nexus_privileges | length > 0
-
-    - name: Create/check roles
-      include_tasks: call_script.yml
-      vars:
-        script_name: setup_roles_from_list
-        args: "{{ nexus_roles }}"
-      when: nexus_roles | length > 0
-
-    - name: Create/check local users
-      include_tasks: call_script.yml
-      vars:
-        script_name: setup_users_from_list
-        args: "{{ nexus_local_users }}"
-      when: nexus_local_users | length > 0
-
-    - name: Create/check ldap users
-      include_tasks: call_script.yml
-      vars:
-        script_name: setup_ldap_users_from_list
-        args: "{{ nexus_ldap_users }}"
-      when: nexus_ldap_users | length > 0
-
     - name: "Digest splited blob list var"
       include_vars: blob_vars.yml
       when: nexus_blob_split | bool
@@ -157,6 +129,34 @@
       vars:
         script_name: create_repos_from_list
         args: "{{ _nexus_repos_global_list }}"
+
+    - name: Create/check privileges
+      include_tasks: call_script.yml
+      vars:
+        script_name: setup_privileges_from_list
+        args: "{{ nexus_privileges }}"
+      when: nexus_privileges | length > 0
+
+    - name: Create/check roles
+      include_tasks: call_script.yml
+      vars:
+        script_name: setup_roles_from_list
+        args: "{{ nexus_roles }}"
+      when: nexus_roles | length > 0
+
+    - name: Create/check local users
+      include_tasks: call_script.yml
+      vars:
+        script_name: setup_users_from_list
+        args: "{{ nexus_local_users }}"
+      when: nexus_local_users | length > 0
+
+    - name: Create/check ldap users
+      include_tasks: call_script.yml
+      vars:
+        script_name: setup_ldap_users_from_list
+        args: "{{ nexus_ldap_users }}"
+      when: nexus_ldap_users | length > 0
 
   when: nexus_run_provisionning | default(true) | bool
 


### PR DESCRIPTION
Nexus 3.19 fails if you use roles containing repo privileges if those repos are not created first.

Reimplementation of #210 with a test for molecule