### PR TITLE
Remove redundant scenario names in molecule.yml

### DIFF
--- a/molecule/default-centos7/molecule.yml
+++ b/molecule/default-centos7/molecule.yml
@@ -44,7 +44,6 @@ provisioner:
     name: ansible-lint
 
 scenario:
-  name: default-centos7
   check_sequence:
     - destroy
     - create

--- a/molecule/default-debian_buster/molecule.yml
+++ b/molecule/default-debian_buster/molecule.yml
@@ -44,7 +44,6 @@ provisioner:
     name: ansible-lint
 
 scenario:
-  name: default-debian_buster
   check_sequence:
     - destroy
     - create

--- a/molecule/default-debian_stretch/molecule.yml
+++ b/molecule/default-debian_stretch/molecule.yml
@@ -44,7 +44,6 @@ provisioner:
     name: ansible-lint
 
 scenario:
-  name: default-debian_stretch
   check_sequence:
     - destroy
     - create

--- a/molecule/default-ubuntu_16.04/molecule.yml
+++ b/molecule/default-ubuntu_16.04/molecule.yml
@@ -44,7 +44,6 @@ provisioner:
     name: ansible-lint
 
 scenario:
-  name: default-ubuntu_16.04
   check_sequence:
     - destroy
     - create

--- a/molecule/default-ubuntu_18.04/molecule.yml
+++ b/molecule/default-ubuntu_18.04/molecule.yml
@@ -44,7 +44,6 @@ provisioner:
     name: ansible-lint
 
 scenario:
-  name: default-ubuntu_18.04
   check_sequence:
     - destroy
     - create

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -42,7 +42,6 @@ provisioner:
     name: ansible-lint
 
 scenario:
-  name: default
   check_sequence:
     - destroy
     - create

--- a/molecule/selinux/molecule.yml
+++ b/molecule/selinux/molecule.yml
@@ -1,14 +1,17 @@
 ---
 dependency:
   name: galaxy
+
 driver:
   name: vagrant
   safe_files:
     - nexus-downloads
   provider:
     name: virtualbox
+
 lint:
   name: yamllint
+
 platforms:
   - name: vb-centos7
     box: thoteam/vb-centos7
@@ -28,12 +31,12 @@ platforms:
       - "vm.network 'forwarded_port', guest: 443, host: 9102"
     groups:
       - nexus
+
 provisioner:
   name: ansible
   lint:
     name: ansible-lint
-scenario:
-  name: selinux
+
 verifier:
   name: testinfra
   lint:


### PR DESCRIPTION
This is redundant and missleading (i.e. when you copy of move a scenario
for example). The default name is the name of the containing folder
which should be more than enough. Moreover, this feature will probably
be deprecated in future releases for performace sake:
https://github.com/ansible/molecule/issues/2434