### PR TITLE
Add more schecule options for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,10 @@ nexus_rut_auth_header: "CUSTOM_HEADER"
 ```
 
 ### Scheduled tasks
+
+These are quick examples and instruction to setup scheduled tasks. For in depth information on available tasks types
+and schedule types, please refer to [the specific section in the repo wiki](https://github.com/ansible-ThoTeam/nexus3-oss/wiki/Scheduled-tasks-configuration)
+
 ```yaml
     nexus_scheduled_tasks: []
     #  #  Example task to compact blobstore :
@@ -683,6 +687,7 @@ nexus_rut_auth_header: "CUSTOM_HEADER"
 **Task properties must be declared in the correct yaml block depending on their type**:
 * `taskProperties` for all string properties (i.e. repository names, blobstore names, time periods...).
 * `booleanTaskProperties` for all boolean properties (i.e. mainly checkboxes in nexus create task GUI).
+
 
 ### Backups
 ```yaml

--- a/files/groovy/create_task.groovy
+++ b/files/groovy/create_task.groovy
@@ -24,9 +24,12 @@ TaskConfiguration taskConfiguration = taskScheduler.createTaskConfigurationInsta
 if (existingTask) {
     taskConfiguration.setId(existingTask.getId())
 }
+
 taskConfiguration.setName(parsed_args.name)
 
 taskConfiguration.setAlertEmail(parsed_args.get('task_alert_email', '') as String)
+
+taskConfiguration.setEnabled(Boolean.valueOf(parsed_args.get('enabled', 'true') as String))
 
 parsed_args.taskProperties.each { key, value ->
     taskConfiguration.setString(key, value)

--- a/files/groovy/create_task.groovy
+++ b/files/groovy/create_task.groovy
@@ -18,16 +18,22 @@ if (existingTask && existingTask.getCurrentState().getRunState() != null) {
 }
 
 TaskConfiguration taskConfiguration = taskScheduler.createTaskConfigurationInstance(parsed_args.typeId)
-if (existingTask) { taskConfiguration.setId(existingTask.getId()) }
+if (existingTask) {
+    taskConfiguration.setId(existingTask.getId())
+}
 taskConfiguration.setName(parsed_args.name)
 
-parsed_args.taskProperties.each { key, value -> taskConfiguration.setString(key, value) }
+parsed_args.taskProperties.each { key, value ->
+    taskConfiguration.setString(key, value)
+}
 
 if (parsed_args.task_alert_email) {
     taskConfiguration.setAlertEmail(parsed_args.task_alert_email)
 }
 
-parsed_args.booleanTaskProperties.each { key, value -> taskConfiguration.setBoolean(key, Boolean.valueOf(value)) }
+parsed_args.booleanTaskProperties.each { key, value ->
+    taskConfiguration.setBoolean(key, Boolean.valueOf(value))
+}
 
 Schedule schedule = null;
 

--- a/files/groovy/create_task.groovy
+++ b/files/groovy/create_task.groovy
@@ -29,6 +29,14 @@ if (parsed_args.task_alert_email) {
 
 parsed_args.booleanTaskProperties.each { key, value -> taskConfiguration.setBoolean(key, Boolean.valueOf(value)) }
 
-Schedule schedule = taskScheduler.scheduleFactory.cron(new Date(), parsed_args.cron)
+Schedule schedule = null;
+
+if (parsed_args.manual) {
+  schedule = taskScheduler.scheduleFactory.manual()
+} else if (parsed_args.once) {
+  schedule = taskScheduler.scheduleFactory.once(new Date())
+} else {
+  schedule = taskScheduler.scheduleFactory.cron(new Date(), parsed_args.cron)
+}
 
 taskScheduler.scheduleTask(taskConfiguration, schedule)

--- a/files/groovy/create_task.groovy
+++ b/files/groovy/create_task.groovy
@@ -2,7 +2,10 @@ import groovy.json.JsonSlurper
 import org.sonatype.nexus.scheduling.TaskConfiguration
 import org.sonatype.nexus.scheduling.TaskInfo
 import org.sonatype.nexus.scheduling.TaskScheduler
+import org.sonatype.nexus.scheduling.schedule.Monthly
 import org.sonatype.nexus.scheduling.schedule.Schedule
+import org.sonatype.nexus.scheduling.schedule.Weekly
+import java.text.SimpleDateFormat
 
 parsed_args = new JsonSlurper().parseText(args)
 
@@ -35,9 +38,34 @@ parsed_args.booleanTaskProperties.each { key, value ->
     taskConfiguration.setBoolean(key, Boolean.valueOf(value))
 }
 
-Schedule schedule = null;
+// Init empty/default vars from script call
 
-switch( parsed_args.schedule_type ) {
+// Type of schedule. Defaults to cron
+type = parsed_args.get('schedule_type', 'cron')
+
+// Cron expression. Used only for cron schecule. Defaults to null
+cron = parsed_args.get('cron', null)
+
+// Start date time. Defaults to now. Unused for manual, now and cron schedules
+// This is our expected date format
+SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
+date_time_string = parsed_args.get('start_date_time', null)
+Date start_date
+if (date_time_string)
+    start_date = dateFormat.parse(date_time_string)
+else
+    start_date = new Date()
+
+// List of weekdays to run task. Used for weekly schedule. Need at least one
+// defaults to null which will error if this schedule is chosen
+weekly_days = parsed_args.get('weekly_days', null)
+
+// List of calendar days to run task. Used for monthly schedule. Need at leas one
+// defaults to null which will error if this schedule is chosen
+monthly_days = parsed_args.get('monthly_days', null)
+
+Schedule schedule
+switch(type) {
     case 'manual':
         schedule = taskScheduler.scheduleFactory.manual()
         break
@@ -45,16 +73,38 @@ switch( parsed_args.schedule_type ) {
         schedule = taskScheduler.scheduleFactory.now()
         break
     case 'once':
-        schedule = taskScheduler.scheduleFactory.once(new Date())
+        schedule = taskScheduler.scheduleFactory.once(start_date)
         break
     case 'hourly':
-        schedule = taskScheduler.scheduleFactory.hourly(new Date())
+        schedule = taskScheduler.scheduleFactory.hourly(start_date)
         break
     case 'daily':
-        schedule = taskScheduler.scheduleFactory.daily(new Date())
+        schedule = taskScheduler.scheduleFactory.daily(start_date)
+        break
+    case 'weekly':
+        if (!weekly_days)
+            throw new Exception('Weekly scehedule requires a weekly_days list parameter')
+        Set<Weekly.Weekday> weekdays = []
+        weekly_days.each { day ->
+            weekdays.add(Weekly.Weekday.valueOf(day))
+        }
+        schedule = taskScheduler.scheduleFactory.weekly(start_date, weekdays)
+        break
+    case 'monthly':
+        if (!monthly_days)
+            throw new Exception('Monthly scehedule requires a weekly_days list parameter')
+        Set<Monthly.CalendarDay> calendardays = []
+        monthly_days.each { day ->
+            calendardays.add(Monthly.CalendarDay.day(day as Integer))
+        }
+        schedule = taskScheduler.scheduleFactory.monthly(start_date, calendardays)
+        break
+    case 'cron':
+        schedule = taskScheduler.scheduleFactory.cron(new Date(), cron)
         break
     default:
-        schedule = taskScheduler.scheduleFactory.cron(new Date(), parsed_args.cron)
+        /** @todo: dont crash, return error in json response **/
+        throw new Exception("Unknown schedule type: " + parsed_args.schedule_type.toString())
         break
 }
 

--- a/files/groovy/create_task.groovy
+++ b/files/groovy/create_task.groovy
@@ -26,12 +26,10 @@ if (existingTask) {
 }
 taskConfiguration.setName(parsed_args.name)
 
+taskConfiguration.setAlertEmail(parsed_args.get('task_alert_email', '') as String)
+
 parsed_args.taskProperties.each { key, value ->
     taskConfiguration.setString(key, value)
-}
-
-if (parsed_args.task_alert_email) {
-    taskConfiguration.setAlertEmail(parsed_args.task_alert_email)
 }
 
 parsed_args.booleanTaskProperties.each { key, value ->

--- a/files/groovy/create_task.groovy
+++ b/files/groovy/create_task.groovy
@@ -31,12 +31,25 @@ parsed_args.booleanTaskProperties.each { key, value -> taskConfiguration.setBool
 
 Schedule schedule = null;
 
-if (parsed_args.manual) {
-  schedule = taskScheduler.scheduleFactory.manual()
-} else if (parsed_args.once) {
-  schedule = taskScheduler.scheduleFactory.once(new Date())
-} else {
-  schedule = taskScheduler.scheduleFactory.cron(new Date(), parsed_args.cron)
+switch( parsed_args.schedule_type ) {
+    case 'manual':
+        schedule = taskScheduler.scheduleFactory.manual()
+        break
+    case 'now':
+        schedule = taskScheduler.scheduleFactory.now()
+        break
+    case 'once':
+        schedule = taskScheduler.scheduleFactory.once(new Date())
+        break
+    case 'hourly':
+        schedule = taskScheduler.scheduleFactory.hourly(new Date())
+        break
+    case 'daily':
+        schedule = taskScheduler.scheduleFactory.daily(new Date())
+        break
+    default:
+        schedule = taskScheduler.scheduleFactory.cron(new Date(), parsed_args.cron)
+        break
 }
 
 taskScheduler.scheduleTask(taskConfiguration, schedule)

--- a/molecule/nexus_common_test_vars.yml
+++ b/molecule/nexus_common_test_vars.yml
@@ -153,8 +153,9 @@ nexus_repos_apt_proxy:
     negative_cache_ttl: 60
 
 nexus_scheduled_tasks:
-  #  Example task to purge maven snapshots
-  - name: Purge-maven-snapshots
+  #  Example task to purge maven snapshots with cron schedule
+  - name: Purge maven snapshots
+    schedule_type: cron
     cron: '0 50 23 * * ?'
     typeId: repository.maven.remove-snapshots
     task_alert_email: alerts@example.org  # optional
@@ -166,36 +167,60 @@ nexus_scheduled_tasks:
     booleanTaskProperties:
       removeIfReleased: true
   #  Example task to run manually, now, once, daily, and hourly
-  - name: Purge-unused-maven-snapshots-manual
+  - name: Purge unused maven snapshots manual
     schedule_type: manual
     typeId: repository.maven.purge-unused-snapshots
     taskProperties:
       repositoryName: "*"
-      lastUsedDays: "1"
+      lastUsed: "1"
   - name: Purge-unused-maven-snapshots-now
     schedule_type: now
     typeId: repository.maven.purge-unused-snapshots
     taskProperties:
       repositoryName: "*"
-      lastUsedDays: "2"
+      lastUsed: "2"
   - name: Purge-unused-maven-snapshots-once
     schedule_type: once
+    start_date_time: "2050-02-02T00:01:02"
     typeId: repository.maven.purge-unused-snapshots
     taskProperties:
       repositoryName: "*"
-      lastUsedDays: "3"
+      lastUsed: "3"
+  - name: Purge-unused-maven-snapshots-monthly
+    schedule_type: monthly
+    start_date_time: "2050-03-03T00:01:02"
+    monthly_days:
+      - 1
+      - 15
+      - 999  # Last day of month
+    typeId: repository.maven.purge-unused-snapshots
+    taskProperties:
+      repositoryName: "*"
+      lastUsed: "4"
+  - name: Purge-unused-maven-snapshots-weekly
+    schedule_type: weekly
+    start_date_time: "2050-04-04T00:01:02"
+    weekly_days:
+      - MON
+      - WED
+    typeId: repository.maven.purge-unused-snapshots
+    taskProperties:
+      repositoryName: "*"
+      lastUsed: "5"
   - name: Purge-unused-maven-snapshots-daily
     schedule_type: daily
+    start_date_time: "2050-05-05T00:01:02"
     typeId: repository.maven.purge-unused-snapshots
     taskProperties:
       repositoryName: "*"
-      lastUsedDays: "4"
+      lastUsed: "6"
   - name: Purge-unused-maven-snapshots-hourly
     schedule_type: hourly
+    start_date_time: "2050-06-06T00:01:02"
     typeId: repository.maven.purge-unused-snapshots
     taskProperties:
       repositoryName: "*"
-      lastUsedDays: "5"
+      lastUsed: "7"
 
 nexus_local_users:
   - username: jenkins

--- a/molecule/nexus_common_test_vars.yml
+++ b/molecule/nexus_common_test_vars.yml
@@ -165,6 +165,22 @@ nexus_scheduled_tasks:
       gracePeriodInDays: "2"
     booleanTaskProperties:
       removeIfReleased: true
+  #  Example task to run manually
+  - name: Purge-unused-maven-snapshots-manual
+    manual: true
+    typeId: repository.maven.purge-unused-snapshots
+    task_alert_email: alerts@example.org  # optional
+    taskProperties:
+      repositoryName: "*"
+      lastUsedDays: "30"
+  #  Example task to run once
+  - name: Purge-unused-maven-snapshots-once
+    once: true
+    typeId: repository.maven.purge-unused-snapshots
+    task_alert_email: alerts@example.org  # optional
+    taskProperties:
+      repositoryName: "*"
+      lastUsedDays: "30"
 
 nexus_local_users:
   - username: jenkins

--- a/molecule/nexus_common_test_vars.yml
+++ b/molecule/nexus_common_test_vars.yml
@@ -165,22 +165,37 @@ nexus_scheduled_tasks:
       gracePeriodInDays: "2"
     booleanTaskProperties:
       removeIfReleased: true
-  #  Example task to run manually
+  #  Example task to run manually, now, once, daily, and hourly
   - name: Purge-unused-maven-snapshots-manual
-    manual: true
+    schedule_type: manual
     typeId: repository.maven.purge-unused-snapshots
-    task_alert_email: alerts@example.org  # optional
     taskProperties:
       repositoryName: "*"
-      lastUsedDays: "30"
-  #  Example task to run once
+      lastUsedDays: "1"
+  - name: Purge-unused-maven-snapshots-now
+    schedule_type: now
+    typeId: repository.maven.purge-unused-snapshots
+    taskProperties:
+      repositoryName: "*"
+      lastUsedDays: "2"
   - name: Purge-unused-maven-snapshots-once
-    once: true
+    schedule_type: once
     typeId: repository.maven.purge-unused-snapshots
-    task_alert_email: alerts@example.org  # optional
     taskProperties:
       repositoryName: "*"
-      lastUsedDays: "30"
+      lastUsedDays: "3"
+  - name: Purge-unused-maven-snapshots-daily
+    schedule_type: daily
+    typeId: repository.maven.purge-unused-snapshots
+    taskProperties:
+      repositoryName: "*"
+      lastUsedDays: "4"
+  - name: Purge-unused-maven-snapshots-hourly
+    schedule_type: hourly
+    typeId: repository.maven.purge-unused-snapshots
+    taskProperties:
+      repositoryName: "*"
+      lastUsedDays: "5"
 
 nexus_local_users:
   - username: jenkins

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     </description>
 
     <properties>
-        <nx-version>3.15.2-01</nx-version>
+        <nx-version>3.19.1-01</nx-version>
     </properties>
 
     <build>


### PR DESCRIPTION
This is a rebase + Fixes and documentation for #173
+ additions from #183 (monthly and weekly schedule)

* Add a new `schedule_type` param for tasks which defaults to "cron".
* Add a new params to support schedule types.
* Adding CI tests and documentation.