### PR TITLE
Add logic to control the Nexus Onboarding Wizard for versions >= 3.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ _(Created with [gh-md-toc](https://github.com/ekalinin/github-markdown-toc))_
          * [Nexus instance directories](#nexus-instance-directories)
          * [Nexus JVM Ram setting](#nexus-jvm-ram-setting)
          * [Plugin installation](#plugin-installation)
+         * [Onboarding Wizard](#onboarding-wizard)
          * [Admin password](#admin-password)
          * [Default anonymous access](#default-anonymous-access)
          * [Public hostname](#public-hostname)
@@ -59,7 +60,7 @@ _(Created with [gh-md-toc](https://github.com/ekalinin/github-markdown-toc))_
       * [License](#license)
       * [Author Information](#author-information)
 
-<!-- Added by: olcla, at: Sat Nov  9 16:00:35 CET 2019 -->
+<!-- Added by: olcla, at: Thu Nov 28 21:55:10 CET 2019 -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ nexus_plugin_urls: []
 ```
 Put list of urls pointing to plugins build for your Nexus version. Only *.kar bundles can be installed this way.
 
+### Onboarding Wizard
+```yaml
+nexus_onboarding_wizard: false
+```
+Controls whether the nexus onboarding wizard runs when the admin user logs in for the first time
+
 ### Admin password
 ```yaml
     nexus_admin_password: 'changeme'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ nexus_timezone: 'UTC'  # java timezone
 nexus_tmp_dir: "{{ (ansible_os_family == 'RedHat') | ternary('/var/nexus-tmp', '/tmp/nexus') }}"
 nexus_script_dir: '{{ nexus_installation_dir }}/nexus-{{ nexus_version }}/etc/scripts'
 nexus_plugin_urls: []
+nexus_onboarding_wizard: false
 
 # These are the default values for JVM Ram
 # don't touch those unless you have read

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -245,6 +245,13 @@
     line: "-XX:MaxDirectMemorySize={{ nexus_max_direct_memory }}"
   notify: nexus-service-stop
 
+- name: Stop the admin wizard from running
+  lineinfile:
+    path: "{{ nexus_default_settings_file }}"
+    line: "nexus.onboarding.enabled={{ nexus_onboarding_wizard }}"
+    create: true
+  when: nexus_version is version_compare('3.17.0', '>=')
+
 - name: Create Nexus tmp/backup directory
   file:
     path: "{{ item }}"


### PR DESCRIPTION
Add `{{ nexus_onboarding_wizard }}` var to control whether the onboarding wizard shows on first admin login (default `nexus_onboarding_wizard: false`) for Nexus version >= 3.17.0

Fixes #192 