### PR TITLE
Adding configuration for creating backup directory or not + fixing backup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,6 +704,7 @@ and schedule types, please refer to [the specific section in the repo wiki](http
       nexus_backup_configure: false
       nexus_backup_cron: '0 0 21 * * ?'  # See cron expressions definition in nexus create task gui
       nexus_backup_dir: '/var/nexus-backup'
+      nexus_backup_dir_create: true
       nexus_restore_log: '{{ nexus_backup_dir }}/nexus-restore.log'
       nexus_backup_rotate: false
       nexus_backup_rotate_first: false
@@ -725,6 +726,8 @@ When using rotation, if you want to save extra disk space during the backup proc
 you can set `nexus_backup_rotate_first: true`. This will configure a pre-rotation
 rather than the default post-rotation. Please note than in this case, old backup(s)
 is/are removed before the current one is done and successful.
+
+If you want to backup to a mounted directory (like s3fs), you can set the `nexus_backup_dir_create` to false.
 
 #### Restore procedure
 Run your playbook with parameter `-e nexus_restore_point=<YYYY-MM-dd-HH-mm-ss>`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ nexus_max_direct_memory: "{{ nexus_min_heap_size }}"
 
 # Nexus Backup
 nexus_backup_dir: '/var/nexus-backup'
-nexus_backup_dir_create: true # Shall we create the dir, or do you already have something in place?
+nexus_backup_dir_create: true  # Shall we create the dir, or do you already have something in place?
 nexus_restore_log: '{{ nexus_backup_dir }}/nexus-restore.log'
 nexus_backup_configure: false  # Shall we configure backup ?
 nexus_backup_cron: "0 0 21 * * ?"  # See cron expression in nexus create task GUI

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ nexus_max_direct_memory: "{{ nexus_min_heap_size }}"
 
 # Nexus Backup
 nexus_backup_dir: '/var/nexus-backup'
-nexus_backup_dir_create: true # whether to create the backup dir or not. useful for backing up to mounted dirs
+nexus_backup_dir_create: true # Shall we create the dir, or do you already have something in place?
 nexus_restore_log: '{{ nexus_backup_dir }}/nexus-restore.log'
 nexus_backup_configure: false  # Shall we configure backup ?
 nexus_backup_cron: "0 0 21 * * ?"  # See cron expression in nexus create task GUI

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,7 @@ nexus_max_direct_memory: "{{ nexus_min_heap_size }}"
 
 # Nexus Backup
 nexus_backup_dir: '/var/nexus-backup'
+nexus_backup_dir_create: true # whether to create the backup dir or not. useful for backing up to mounted dirs
 nexus_restore_log: '{{ nexus_backup_dir }}/nexus-restore.log'
 nexus_backup_configure: false  # Shall we configure backup ?
 nexus_backup_cron: "0 0 21 * * ?"  # See cron expression in nexus create task GUI

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -252,15 +252,20 @@
     create: true
   when: nexus_version is version_compare('3.17.0', '>=')
 
-- name: Create Nexus tmp/backup directory
+- name: Create Nexus tmp directory
   file:
-    path: "{{ item }}"
+    path: "{{ nexus_tmp_dir }}"
     state: "directory"
     owner: "{{ nexus_os_user }}"
     group: "{{ nexus_os_group }}"
-  with_items:
-    - "{{ nexus_tmp_dir }}"
-    - "{{ nexus_backup_dir }}"
+
+- name: Create Nexus backup directory
+  file:
+    path: "{{ nexus_backup_dir }}"
+    state: "directory"
+    owner: "{{ nexus_os_user }}"
+    group: "{{ nexus_os_group }}"
+  when: nexus_backup_dir_create | bool
 
 - name: Setup Nexus tmp directory
   lineinfile:

--- a/templates/backup.groovy.j2
+++ b/templates/backup.groovy.j2
@@ -84,7 +84,7 @@ try {
     FileUtils.copyDirectory(new File(nexusDataDirPath+'/blobs'), new File(CurrentBackupDirPath))
 
     log.info("Wait for temporary db backup task to finish")
-    while (tempBackupTask.currentState.state != TaskInfo.State.WAITING) {
+    while (tempBackupTask.currentState.state.name().toUpperCase() != "WAITING") {
         TimeUnit.SECONDS.sleep(1)
     }
     log.info("Remove temporary task")

--- a/templates/backup.groovy.j2
+++ b/templates/backup.groovy.j2
@@ -84,7 +84,7 @@ try {
     FileUtils.copyDirectory(new File(nexusDataDirPath+'/blobs'), new File(CurrentBackupDirPath))
 
     log.info("Wait for temporary db backup task to finish")
-    while (tempBackupTask.currentState.state.name().toUpperCase() != "WAITING") {
+    while (tempBackupTask.currentState.state.name() != "WAITING") {
         TimeUnit.SECONDS.sleep(1)
     }
     log.info("Remove temporary task")

--- a/templates/backup.groovy.j2
+++ b/templates/backup.groovy.j2
@@ -84,7 +84,7 @@ try {
     FileUtils.copyDirectory(new File(nexusDataDirPath+'/blobs'), new File(CurrentBackupDirPath))
 
     log.info("Wait for temporary db backup task to finish")
-    while (tempBackupTask.currentState.state.name() != "WAITING") {
+    while (tempBackupTask.currentState.getState().toString() != "WAITING") {
         TimeUnit.SECONDS.sleep(1)
     }
     log.info("Remove temporary task")

--- a/templates/backup.groovy.j2
+++ b/templates/backup.groovy.j2
@@ -4,7 +4,6 @@ import java.time.format.DateTimeFormatter
 import org.sonatype.nexus.scheduling.TaskConfiguration
 import org.sonatype.nexus.scheduling.TaskScheduler
 import org.sonatype.nexus.scheduling.TaskInfo
-import org.sonatype.nexus.scheduling.TaskState
 import org.sonatype.nexus.scheduling.schedule.Schedule
 import java.util.concurrent.TimeUnit
 
@@ -85,7 +84,7 @@ try {
     FileUtils.copyDirectory(new File(nexusDataDirPath+'/blobs'), new File(CurrentBackupDirPath))
 
     log.info("Wait for temporary db backup task to finish")
-    while (tempBackupTask.currentState.state != TaskState.WAITING) {
+    while (tempBackupTask.currentState.state.name().toUpperCase() != "WAITING") {
         TimeUnit.SECONDS.sleep(1)
     }
     log.info("Remove temporary task")

--- a/templates/backup.groovy.j2
+++ b/templates/backup.groovy.j2
@@ -4,6 +4,7 @@ import java.time.format.DateTimeFormatter
 import org.sonatype.nexus.scheduling.TaskConfiguration
 import org.sonatype.nexus.scheduling.TaskScheduler
 import org.sonatype.nexus.scheduling.TaskInfo
+import org.sonatype.nexus.scheduling.TaskState
 import org.sonatype.nexus.scheduling.schedule.Schedule
 import java.util.concurrent.TimeUnit
 
@@ -84,7 +85,7 @@ try {
     FileUtils.copyDirectory(new File(nexusDataDirPath+'/blobs'), new File(CurrentBackupDirPath))
 
     log.info("Wait for temporary db backup task to finish")
-    while (tempBackupTask.currentState.state.name().toUpperCase() != "WAITING") {
+    while (tempBackupTask.currentState.state != TaskState.WAITING) {
         TimeUnit.SECONDS.sleep(1)
     }
     log.info("Remove temporary task")


### PR DESCRIPTION
Fixes #226 (implementation)
Fixes #228 

Originally I had wanted to make this role support s3fs, but because there's a lot of ways this can be made to work, I think it's best to just leave the mounting/s3fs setup stuff to the developer instead of the role. The configuration for it is simple as well (see https://github.com/ansible-ThoTeam/nexus3-oss/issues/226#issuecomment-568531393 for my example using an amazon ami). Additionally, creating logic (tests in particular) for checking S3 permissions will probably complicate stuff.

If someone wants to take on the task of providing real S3 support, please do. But as for now, I think this PR should make it viable to set up s3fs outside of this role and not need to worry about it failing just because it can't create a directory with 0777 permissions/can't change ownership to nexus:nexus, et. al.


Edit: I made an additional change to the backup script. I was noticing the following failure:
```
2019-12-23 19:23:27,822+0000 ERROR [quartz-5-thread-20]  *SYSTEM org.sonatype.nexus.internal.script.ScriptTask - groovy.lang.MissingPropertyException: No such property: State for class: org.sonatype.nexus.scheduling.TaskInfo
Possible solutions: name
```

This caused the backup script to fail to run. Looks like latest nexus moved things into a TaskState class. I initially changed it to do a string comparison, but decided to change it to enum as, hey, maybe they won't move stuff around in the future.