### PR TITLE
Use normal year instead of week-based-year for backup names

### DIFF
--- a/templates/backup.groovy.j2
+++ b/templates/backup.groovy.j2
@@ -26,7 +26,7 @@ nexusBackupRotate = Boolean.valueOf("{{ nexus_backup_rotate }}")
 nexusBackupRotateFirst = Boolean.valueOf("{{ nexus_backup_rotate_first }}")
 nexusBackupKeepRotations = "{{ nexus_backup_keep_rotations }}".toInteger()
 
-backupDateString = LocalDateTime.now().format(DateTimeFormatter.ofPattern('YYYY-MM-dd-HH-mm-ss'))
+backupDateString = LocalDateTime.now().format(DateTimeFormatter.ofPattern('yyyy-MM-dd-HH-mm-ss'))
 CurrentBackupDirPath = nexusBackupDirPath+'/blob-backup-'+backupDateString
 
 /** Helper function to rotate backups */


### PR DESCRIPTION
Week-based-year is probably not what people expect here and could easily trip up scripts trying to extract dates from the backup names.
