### PR TITLE
Turn off recursive ownership check of blobstores dirs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ _(Created with [gh-md-toc](https://github.com/ekalinin/github-markdown-toc))_
             * [Upgrade nexus to latest version](#upgrade-nexus-to-latest-version)
                * [Fix upgrade failing on timeout waiting for nexus port](#fix-upgrade-failing-on-timeout-waiting-for-nexus-port)
             * [Skip provisionning tasks](#skip-provisionning-tasks)
+            * [Force recursive ownership check of blobstores directories](#force-recursive-ownership-check-of-blobstores-directories)
       * [Dependencies](#dependencies)
       * [Example Playbook](#example-playbook)
       * [Development, Contribution and Testing](#development-contribution-and-testing)
@@ -67,7 +68,7 @@ _(Created with [gh-md-toc](https://github.com/ekalinin/github-markdown-toc))_
       * [License](#license)
       * [Author Information](#author-information)
 
-<!-- Added by: olcla, at: Thu Nov 28 23:04:38 CET 2019 -->
+<!-- Added by: olcla, at: Thu Feb 13 18:48:38 CET 2020 -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -870,6 +870,22 @@ We strongly suggest to use this variable only as an extra var to ansible-playboo
 ansible-playbook -i your/inventory.ini your_playbook.yml -e nexus_run_provisionning=false
 ```
 
+#### Force recursive ownership check of blobstores directories
+_Introduced in version 2.4.9_
+```yaml
+    nexus_blobstores_recurse_owner: true
+```
+In versions prior to 2.4.9, the task creating the blobstores directories was recursively checking the ownership
+of all files. This was not a problem on creation (where dir is empty) or with installations with small
+blobstores, but could lead to extremely long delays for large blobstores with lots of files.
+
+Recursive checking of ownership has been turned off by default to prevent this extra delay. If for some
+reason you need to make sure all files in the blobstore directories are owned by the nexus user, you can
+force the check:
+```bash
+ansible-playbook -i your/inventory.ini your_playbook.yml -e nexus_blobstores_recurse_owner=true
+```
+
 ## Dependencies
 
 The java and httpd requirements /can/ be fulfilled with the following galaxy roles :

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -107,7 +107,7 @@
             owner: "{{ nexus_os_user }}"
             group: "{{ nexus_os_group }}"
             state: directory
-            recurse: true
+            recurse: "{{ nexus_blobstores_recurse_owner | default(false) | bool }}"
           when: item.path is defined
           loop: "{{ nexus_blobstores }}"
 


### PR DESCRIPTION
... for performance sake on installs containing large blobstores