### PR TITLE
Fix blobstore restore script when splitted blobstore is on

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,10 @@
 - include_tasks: nexus_purge.yml
   when: nexus_purge | default(false) | bool
 
+- name: "Digest splited blob list var"
+  include_vars: blob_vars.yml
+  when: nexus_blob_split | bool
+
 - import_tasks: nexus_install.yml
 
 - include_tasks: httpd_reverse_proxy_config.yml
@@ -92,10 +96,6 @@
             {{ result.append(_nexus_privilege_defaults | combine(privilege)) }}
           {%- endfor -%}
           {{ result | to_json | from_json }}
-
-    - name: "Digest splited blob list var"
-      include_vars: blob_vars.yml
-      when: nexus_blob_split | bool
 
     - name: Create/Check blobstores
       when: nexus_restore_point is undefined

--- a/templates/nexus-blob-restore.sh.j2
+++ b/templates/nexus-blob-restore.sh.j2
@@ -24,8 +24,8 @@ else
   rm -rf ${data_dir}/db/*
   rm -rf ${data_dir}/blobs/*
   sudo -u {{ nexus_os_user }} cp ${backup_dir}/${blob_dir}/db/* ${db_restore_dir}
-  {% for item in nexus_blobstores %}
+{% for item in nexus_blobstores %}
   sudo -u {{ nexus_os_user }} cp -r ${backup_dir}/${blob_dir}/{{ item.name }} ${data_dir}/blobs/
-  {% endfor %}
+{% endfor %}
   sudo -u {{ nexus_os_user }} cp -r ${backup_dir}/${blob_dir}/default ${data_dir}/blobs/
 fi


### PR DESCRIPTION
Collateral damage of #241. When split blobstores is on
blobstore list was not valorised early enough
and blobstore restore script was buggy.