### PR TITLE
Maintenance for CI process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@
 
 sudo: required
 language: python
-python: 3.6
+
+python: 3.8
+
 cache:
   pip: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
-
 sudo: required
+
 language: python
 
 python: 3.8
@@ -9,17 +9,19 @@ cache:
   pip: true
   directories:
     - molecule/.nexus-downloads/
+
 services:
   - docker
+
 install:
   - pip install --upgrade --upgrade-strategy eager -r requirements.txt
+
 env:
   - SCENARIO=default
-  - SCENARIO=default-centos7
+  - SCENARIO=default-centos8
   - SCENARIO=default-debian_buster
-  - SCENARIO=default-debian_stretch
   - SCENARIO=default-ubuntu_18.04
-  - SCENARIO=default-ubuntu_16.04
+
 script: |
   if [ "${SCENARIO}" == "default" ]; then
     ./tests/test_groovySyntax.sh
@@ -27,5 +29,6 @@ script: |
   else
     molecule test -s "${SCENARIO}"
   fi
+
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ We would like to thank the original authors for the work done.
 
 - Fairly Up-to-date version of ansible. We follow ansible versions during maintenance/development and will take advantage
 of new features if needed (and update meta/main.yml for minimum version)
-- Compatible OS. This role is tested through travis CI on CentOS 7, Ubuntu Xenial (16.04) and Bionic (18.04),
-Debian stretch and buster for time being.
+- Compatible OS. This role is tested through molecule on travis CI for CentOS 8, Ubuntu Bionic (18.04),
+ and Debian buster. Other molecule scenarios can be played locally for CentOS 7, Ubuntu Xenial (16.04), and Debian stretch
 - Rsync has to be installed on the target machine (it is not needed on the host running ansible if different)
 - `jmespath` library needs to be installed on the host running the playbook (needed for the `json_query` filter). See `requirements.txt`
 - Java 8 (mandatory)
@@ -1030,12 +1030,16 @@ This role includes tests and CI integration through travis. At time being, we te
 * groovy scripts syntax
 * yaml syntax and coding standard (yamllint)
 * ansible good practices (ansible lint)
-* a set of basic deployments on 5 different linux platforms
-    * centos7
-    * debian stretch
-    * debian buster
-    * ubuntu xenial (16.04)
-    * ubuntu bionic (18.04)
+* a set of basic deployments on 3 different linux platforms
+    * Centos 8
+    * Debian buster
+    * Ubuntu bionic (18.04)
+
+Other tests are available for older platforms but not played on CI for performance reasons:
+* Centos 7
+* Debian stretch
+* Ubuntu xenial (16.04)
+
 
 #### Groovy syntax
 
@@ -1064,6 +1068,7 @@ Please have a look at molecule documentation (a good start is `molecule --help`)
 
 The current proposed scenarii refer to the tested platforms (see `molecule/` directory). If you launch a scenario ans leave the container running (i.e. using `converge` for a simple deploy), you can access the running instance from your browser at https://localhost:<linkedPort>. See the `molecule/<scenario>/molecule.yml` file for detail. As a convenience, here is the correspondence between scenarii and configured ports:
 * default-centos7 => https://localhost:8090
+* default-centos8 => https://localhost:8095
 * default-debian_buster => https://localhost:8091
 * default-debian_stretch => https://localhost:8092
 * default-ubuntu_16.04 => https://localhost:8093

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,14 +14,15 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
     - name: Ubuntu
       versions:
         - xenial
         - bionic
     - name: Debian
       versions:
-        - jessie
         - stretch
+        - buster
 
   galaxy_tags:
     - nexus

--- a/molecule/default-centos7/molecule.yml
+++ b/molecule/default-centos7/molecule.yml
@@ -23,6 +23,7 @@ platforms:
     privileged: true
     published_ports:
       - 8090:443
+    override_command: false
     groups:
       - nexus
     networks: &nexus_networks

--- a/molecule/default-centos7/molecule.yml
+++ b/molecule/default-centos7/molecule.yml
@@ -18,7 +18,6 @@ platforms:
   - name: nexus3-oss-centos-7
     hostname: nexus3-oss-centos7
     image: thoteam/molecule_apache_openjdk8:centos7
-    command: /usr/sbin/init
     pull: true
     pre_build_image: true
     privileged: true

--- a/molecule/default-centos8/converge.yml
+++ b/molecule/default-centos8/converge.yml
@@ -1,0 +1,2 @@
+---
+- import_playbook: ../default-converge.yml

--- a/molecule/default-centos8/molecule.yml
+++ b/molecule/default-centos8/molecule.yml
@@ -24,6 +24,8 @@ platforms:
     published_ports:
       - 8095:443
     override_command: false
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     groups:
       - nexus
     networks: &nexus_networks

--- a/molecule/default-centos8/molecule.yml
+++ b/molecule/default-centos8/molecule.yml
@@ -18,7 +18,6 @@ platforms:
   - name: nexus3-oss-centos-8
     hostname: nexus3-oss-centos8
     image: thoteam/molecule_apache_openjdk8:centos8
-    command: /usr/sbin/init
     pull: true
     pre_build_image: true
     privileged: true

--- a/molecule/default-centos8/molecule.yml
+++ b/molecule/default-centos8/molecule.yml
@@ -1,0 +1,70 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+  safe_files:
+    - nexus-downloads
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+
+platforms:
+
+  - name: nexus3-oss-centos-8
+    hostname: nexus3-oss-centos8
+    image: thoteam/molecule_apache_openjdk8:centos8
+    command: /usr/sbin/init
+    pull: true
+    pre_build_image: true
+    privileged: true
+    published_ports:
+      - 8095:443
+    groups:
+      - nexus
+    networks: &nexus_networks
+      - name: nexus-default
+
+  - name: slapd-server-mock
+    hostname: slapd-server-mock
+    image: thoteam/slapd-server-mock:latest
+    override_command: false
+    pull: true
+    pre_build_image: true
+    env:
+      LDAP_DOMAIN: slapd-server-mock
+    groups:
+      - mockldap
+    networks: *nexus_networks
+
+provisioner:
+  name: ansible
+
+scenario:
+  check_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - destroy
+  converge_sequence:
+    - create
+    - prepare
+    - converge
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - check
+    - verify
+    - destroy
+
+verifier:
+  name: testinfra

--- a/molecule/default-centos8/molecule.yml
+++ b/molecule/default-centos8/molecule.yml
@@ -23,6 +23,7 @@ platforms:
     privileged: true
     published_ports:
       - 8095:443
+    override_command: false
     groups:
       - nexus
     networks: &nexus_networks

--- a/molecule/default-centos8/prepare.yml
+++ b/molecule/default-centos8/prepare.yml
@@ -1,0 +1,2 @@
+---
+- import_playbook: ../default-prepare.yml

--- a/molecule/default-centos8/tests/test_default.py
+++ b/molecule/default-centos8/tests/test_default.py
@@ -1,0 +1,1 @@
+../../test_default.py

--- a/molecule/sync-nexus-package.yml
+++ b/molecule/sync-nexus-package.yml
@@ -23,7 +23,7 @@
         status_code: 302
       register: nexus_latest_uri_call
 
-    - name: get the current nexus version
+    - name: Get the current nexus version
       get_url:
         url: "{{ nexus_latest_uri_call.location }}"
         dest: "{{ molecule_project_dir }}/molecule/.nexus-downloads\
@@ -37,7 +37,7 @@
     molecule_project_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
   tasks:
 
-    - name: copy nexus package(s) do default image location into images
+    - name: Copy nexus package(s) to default location into images
       synchronize:
         src: "{{ molecule_project_dir }}/molecule/.nexus-downloads/"
         dest: "/tmp/"


### PR DESCRIPTION
* CI now uses python 3.8
* New centos8 scenario
* All scenarios are kept but only latest platform
  versions are tested on CI.
* Minor typos fix on prepare playbook task names