### PR TITLE
Ignore lost+found while checking if data directory is empty

### DIFF
--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -356,7 +356,7 @@
   when: nexus_backup_configure | bool
 
 - name: 'Check if data directory is empty (first-time install)'
-  command: "ls {{ nexus_data_dir }}"
+  command: "ls --ignore=lost+found {{ nexus_data_dir }}"
   register: nexus_data_dir_contents
   check_mode: no
   changed_when: false


### PR DESCRIPTION
Fix checking if the data directory is empty for external drives with created only partition.

Fixes #279 