### PR TITLE
Remove force=no from unarchive invocation

### DIFF
--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -101,7 +101,6 @@
     src: "{{ nexus_download_dir }}/{{ nexus_package }}"
     dest: "{{ nexus_installation_dir }}"
     creates: "{{ nexus_installation_dir }}/nexus-{{ nexus_version }}"
-    force: no
     copy: false
   notify:
     - nexus-service-stop


### PR DESCRIPTION
This parameter doesn't exist anymore in Ansible 2.10+. Also it didn't do much before, because force=no was the default behaviour anyway.