### PR TITLE
Add explicit file permissions to tasks

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,2 @@
+skip_list:
+  - '106'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern

--- a/tasks/httpd_reverse_proxy_config.yml
+++ b/tasks/httpd_reverse_proxy_config.yml
@@ -4,6 +4,7 @@
   template:
     src: "nexus-vhost.conf"
     dest: "{{ httpd_config_dir }}"
+    mode: 0644
   notify:
     - httpd-service-reload
     - wait-for-httpd

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -95,6 +95,7 @@
   file:
     path: "{{ nexus_installation_dir }}"
     state: "directory"
+    mode: 0755
 
 - name: Unpack Nexus download
   unarchive:
@@ -102,6 +103,7 @@
     dest: "{{ nexus_installation_dir }}"
     creates: "{{ nexus_installation_dir }}/nexus-{{ nexus_version }}"
     copy: false
+    mode: 0755
   notify:
     - nexus-service-stop
 
@@ -198,6 +200,7 @@
     state: "directory"
     owner: "{{ nexus_os_user }}"
     group: "{{ nexus_os_group }}"
+    mode: 0750
 
 - name: Setup Nexus data directory
   lineinfile:
@@ -249,6 +252,7 @@
     path: "{{ nexus_default_settings_file }}"
     line: "nexus.onboarding.enabled={{ nexus_onboarding_wizard }}"
     create: true
+    mode: 0644
   when: nexus_version is version_compare('3.17.0', '>=')
 
 - name: Create Nexus tmp directory
@@ -257,6 +261,7 @@
     state: "directory"
     owner: "{{ nexus_os_user }}"
     group: "{{ nexus_os_group }}"
+    mode: 0750
 
 - name: Create Nexus backup directory
   file:
@@ -264,6 +269,7 @@
     state: "directory"
     owner: "{{ nexus_os_user }}"
     group: "{{ nexus_os_group }}"
+    mode: 0750
   when: nexus_backup_dir_create | bool
 
 - name: Setup Nexus tmp directory
@@ -330,6 +336,7 @@
   template:
     src: "nexus.service"
     dest: "/etc/systemd/system"
+    mode: 0644
   notify:
     - systemd-reload
   when: "ansible_service_mgr == 'systemd'"
@@ -502,6 +509,7 @@
     state: directory
     owner: root
     group: root
+    mode: 0755
   with_items:
     - "{{ nexus_data_dir }}/groovy-raw-scripts/current"
     - "{{ nexus_data_dir }}/groovy-raw-scripts/new"
@@ -511,6 +519,7 @@
   archive:
     path: "{{ role_path }}/files/groovy/*"
     dest: "/tmp/nexus-upload-groovy-scripts.tar.gz"
+    mode: 0644
   run_once: true
   delegate_to: localhost
 
@@ -518,6 +527,7 @@
   unarchive:
     src: "/tmp/nexus-upload-groovy-scripts.tar.gz"
     dest: "{{ nexus_data_dir }}/groovy-raw-scripts/new/"
+    mode: 0644
 
 - block:
     - name: Sync new scripts to old and get differences

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -101,7 +101,6 @@
     src: "{{ nexus_download_dir }}/{{ nexus_package }}"
     dest: "{{ nexus_installation_dir }}"
     creates: "{{ nexus_installation_dir }}/nexus-{{ nexus_version }}"
-    force: no
     copy: false
   notify:
     - nexus-service-stop


### PR DESCRIPTION
There is security issue [CVE-2020-1736](https://nvd.nist.gov/vuln/detail/CVE-2020-1736) about file permissions in Ansible modules. There was straight forward attempt to fix it, but it ended breaking a lot of modules and was reverted (more at https://github.com/ansible/ansible/issues/71200). So I've explicitly added `mode` option to the role tasks to support any further changes in Ansible.

Also added `ansible-lint` rule [106:  Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern](https://ansible-lint.readthedocs.io/en/latest/default_rules.html#role-name-does-not-match-a-z-a-z0-9-pattern) to skip-list.

Fixes https://github.com/ansible-ThoTeam/nexus3-oss/issues/302

PR https://github.com/ansible-ThoTeam/nexus3-oss/pull/303 has been already merged into this PR.

