### PR TITLE
fix typo in check of deprecated variable public_hostname

### DIFF
--- a/tasks/requirements_and_deprecated.yml
+++ b/tasks/requirements_and_deprecated.yml
@@ -56,7 +56,7 @@
       Fix this by setting a correct value for nexus_public_hostname and remove public_hostname if
       possible.
   when: >-
-    public_hosname | default('') | length > 0
+    public_hostname | default('') | length > 0
     and
     public_hostname != nexus_public_hostname
     and


### PR DESCRIPTION
There is a small typo error **on line 59** of file below on first occurence of  **`public_hosname`**  in `when` condition of task : 

`name: Variable refactoring - public_hostname is now nexus_public_hostname`
