### PR TITLE
Explicitly specify the IP address to check for port availability

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -41,6 +41,7 @@
 
 - name: wait-for-nexus-port
   wait_for:
+    host: "{{ (nexus_application_host == '0.0.0.0') | ternary('127.0.0.1', nexus_application_host) }}"
     port: "{{ nexus_default_port }}"
     timeout: "{{ nexus_wait_for_port_timeout | default(omit) }}"
   retries: "{{ nexus_wait_for_port_retries | default(omit) }}"


### PR DESCRIPTION
The default host for the `wait_for` ansible module is 127.0.0.1.

If the `nexus_application_host` is not set to "0.0.0.0" or "127.0.0.1", the `wait-for-nexus-port` handler will fail.

This will provide the actual address for checking the port.