### PR TITLE
fix error: ls: unrecognized option: ignore=lost+found

### DIFF
--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -362,16 +362,15 @@
   when: nexus_backup_configure | bool
 
 - name: 'Check if data directory is empty (first-time install)'
-  command: "ls --ignore=lost+found {{ nexus_data_dir }}"
+  find: paths={{ nexus_data_dir }} excludes='lost+found'
   register: nexus_data_dir_contents
-  check_mode: no
   changed_when: false
 
 - name: Clean cache for upgrade process
   file:
     path: "{{ nexus_data_dir }}/clean_cache"
     state: touch
-  when: nexus_latest_version.changed and nexus_data_dir_contents.stdout | length > 0
+  when: nexus_latest_version.changed and nexus_data_dir_contents.matched | int > 0
   tags:
     # hard to run as a handler for time being
     - skip_ansible_lint


### PR DESCRIPTION
`ls --ignore` will fail on busybox distributions like alpine

Ansible already provides a platform-independent method for finding
files, cf. https://docs.ansible.com/ansible/latest/collections/ansible/builtin/find_module.html#ansible-collections-ansible-builtin-find-module

fixes #323