### PR TITLE
Enforce docker http port number as Integer

### DIFF
--- a/files/groovy/create_repos_from_list.groovy
+++ b/files/groovy/create_repos_from_list.groovy
@@ -173,10 +173,12 @@ parsed_args.each { currentRepo ->
 
         // Configs for all docker repos
         if (currentRepo.format == 'docker') {
+            def dockerPort = currentRepo.get('http_port', '')
+            dockerPort = !(dockerPort instanceof String) ? dockerPort as String : dockerPort
             configuration.attributes['docker'] = [
                     forceBasicAuth: currentRepo.force_basic_auth,
                     v1Enabled     : currentRepo.v1_enabled,
-                    httpPort      : currentRepo.get('http_port', '')
+                    httpPort      : dockerPort?.isInteger() ? dockerPort.toInteger() : null
             ]
         }
 


### PR DESCRIPTION
Passing docker port as a string in the cofiguration works.
But it later breaks calls to the the /v1/repositories/docker/* api endpoints.
For example, asking for the current config of an existing repository
will return default ports instead of the current configured port.

This PR forces to push the port as an int inside the configuration to fix this issue

Fixes #262