### PR TITLE
Allow to configure api calls timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,9 +266,14 @@ The fully qualified domain name and scheme under which the nexus instance will b
     nexus_api_validate_certs: "{{ nexus_api_scheme == 'https' }}"
     nexus_api_context_path: "{{ nexus_default_context_path }}"
     nexus_api_port: "{{ nexus_default_port }}"
+    nexus_api_timeout: 60
 ```
 These vars control how the role connects to the nexus API for provisionning.
 **For advance usage only. You most probably do not want to change these default settings**
+
+Note: the `nexus_api_timeout` was added in v2.4.19 and overrides the default
+[`uri` module timeout](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/uri_module.html) of 30s 
+for all calls to the API
 
 ### Branding capabalities
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,6 +86,7 @@ nexus_api_scheme: http
 nexus_api_validate_certs: "{{ nexus_api_scheme == 'https' }}"
 nexus_api_context_path: "{{ nexus_default_context_path }}"
 nexus_api_port: "{{ nexus_default_port }}"
+nexus_api_timeout: 60
 
 # security realms
 nexus_nuget_api_key_realm: false

--- a/molecule/nexus_common_test_vars.yml
+++ b/molecule/nexus_common_test_vars.yml
@@ -5,6 +5,7 @@ httpd_copy_ssl_files: false
 httpd_ssl_cert_file_location: "{{ default_cert }}"
 httpd_ssl_cert_key_location: "{{ default_key }}"
 nexus_public_hostname: localhost
+nexus_api_timeout: 45
 
 nexus_custom_jvm_settings:
   - XX:+UseG1GC

--- a/tasks/call_script.yml
+++ b/tasks/call_script.yml
@@ -4,6 +4,7 @@
       uri:
         url: "{{ nexus_api_scheme }}://{{ nexus_api_hostname }}:{{ nexus_api_port }}\
           {{ nexus_api_context_path }}{{ nexus_rest_api_endpoint }}/{{ script_name }}/run"
+        timeout: "{{ nexus_api_timeout }}"
         user: 'admin'
         password: "{{ current_nexus_admin_password }}"
         headers:

--- a/tasks/call_script.yml
+++ b/tasks/call_script.yml
@@ -4,7 +4,7 @@
       uri:
         url: "{{ nexus_api_scheme }}://{{ nexus_api_hostname }}:{{ nexus_api_port }}\
           {{ nexus_api_context_path }}{{ nexus_rest_api_endpoint }}/{{ script_name }}/run"
-        timeout: "{{ nexus_api_timeout }}"
+        timeout: "{{ nexus_api_timeout | int }}"
         user: 'admin'
         password: "{{ current_nexus_admin_password }}"
         headers:

--- a/tasks/declare_script_each.yml
+++ b/tasks/declare_script_each.yml
@@ -3,7 +3,7 @@
   uri:
     url: "{{ nexus_api_scheme }}://{{ nexus_api_hostname }}:{{ nexus_api_port }}\
       {{ nexus_api_context_path }}{{ nexus_rest_api_endpoint }}/{{ item }}"
-    timeout: "{{ nexus_api_timeout }}"
+    timeout: "{{ nexus_api_timeout | int }}"
     user: 'admin'
     password: "{{ current_nexus_admin_password }}"
     method: DELETE
@@ -15,7 +15,7 @@
   uri:
     url: "{{ nexus_api_scheme }}://{{ nexus_api_hostname }}:{{ nexus_api_port }}\
       {{ nexus_api_context_path }}{{ nexus_rest_api_endpoint }}"
-    timeout: "{{ nexus_api_timeout }}"
+    timeout: "{{ nexus_api_timeout | int }}"
     user: 'admin'
     password: "{{ current_nexus_admin_password }}"
     body_format: json

--- a/tasks/declare_script_each.yml
+++ b/tasks/declare_script_each.yml
@@ -3,6 +3,7 @@
   uri:
     url: "{{ nexus_api_scheme }}://{{ nexus_api_hostname }}:{{ nexus_api_port }}\
       {{ nexus_api_context_path }}{{ nexus_rest_api_endpoint }}/{{ item }}"
+    timeout: "{{ nexus_api_timeout }}"
     user: 'admin'
     password: "{{ current_nexus_admin_password }}"
     method: DELETE
@@ -14,6 +15,7 @@
   uri:
     url: "{{ nexus_api_scheme }}://{{ nexus_api_hostname }}:{{ nexus_api_port }}\
       {{ nexus_api_context_path }}{{ nexus_rest_api_endpoint }}"
+    timeout: "{{ nexus_api_timeout }}"
     user: 'admin'
     password: "{{ current_nexus_admin_password }}"
     body_format: json


### PR DESCRIPTION
Some groovy scripts, especially when provisioning from scratch with large number of objects, can take longer that the default timeout of the `uri` module (30s) to complete.

This PR introduces a new `nexus_api_timeout` parameter and raises the default timeout for API calls from 30 to 60 seconds.

Fixes #325