### PR TITLE
Feature: Add retries to download

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ Ansible variables, along with the default values (see `default/main.yml`) :
 
 The role will install latest nexus available version by default. You may fix the version by setting
 the `nexus_version` variable. See available versions at https://www.sonatype.com/download-oss-sonatype.
+When having a slow pull through proxy, a retry can be useful to prevent timeouts. You can add retries to the download by setting these variables:
+```yaml
+    nexus_download_retries: 3 # 0 by default
+    nexus_download_delay: 15
+```
+
 
 If you fix the version and change it to a different one, the role will try to upgrade your installation.
 **Make sure to change to a later version in release history**. Downgrading will fail (unless you re-install

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,8 @@ nexus_version: ''
 
 nexus_download_dir: '/tmp'
 nexus_download_url: 'https://download.sonatype.com/nexus/3'
+nexus_download_retries: 0
+nexus_download_delay: 15
 nexus_os_group: 'nexus'
 nexus_os_user: 'nexus'
 nexus_os_user_home_dir: '/home/{{ nexus_os_user }}'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -64,6 +64,6 @@
     delay: 5
   listen: wait-for-httpd
 
-- name: relabel nexus binary according to new context
+- name: Relabel nexus binary according to new context
   ansible.builtin.command: "restorecon -irv {{ nexus_installation_dir }}/nexus-{{ nexus_version }}/bin/nexus"
   listen: restore_nexus_selinux_context

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -79,8 +79,8 @@
   check_mode: no
   register: download_status
   until: download_status.status_code == 200
-  retries: 3
-  delay: 15
+  retries: "{{ nexus_download_retries }}"
+  delay: "{{ nexus_download_delay }}"
   notify:
     - nexus-service-stop
 

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -77,6 +77,10 @@
     group: root
     mode: 0644
   check_mode: no
+  register: download_status
+  until: download_status.status_code == 200
+  retries: 3
+  delay: 15
   notify:
     - nexus-service-stop
 


### PR DESCRIPTION
This PR adds a retry to the download of the Nexus package.

We currently use this role to install Nexus. However, we also use an existing Nexus which serves as a proxy for the Nexus packages. When downloading a newer version that is not yet available, the installation can fail because of a timeout when the new artifact is still downloading (with a slower internet connection, this is a common issue we have). Adding a retry is a solution for this issue.

Current behavior isn't changed because of the introduction of two new variables (which are also documented in the readme)
```yaml
    nexus_download_retries: 3 # 0 by default
    nexus_download_delay: 15
```
