### PR TITLE
Enable provisioning offline repositories closes #290

### DIFF
--- a/files/groovy/create_repos_from_list.groovy
+++ b/files/groovy/create_repos_from_list.groovy
@@ -52,7 +52,7 @@ parsed_args.each { currentRepo ->
             configuration = newConfiguration(
                     repositoryName: currentRepo.name,
                     recipeName: recipeName,
-                    online: true,
+                    online: currentRepo.get('online', true),
                     attributes: [
                             storage: [
                                     blobStoreName: currentRepo.blob_store

--- a/molecule/nexus_common_test_vars.yml
+++ b/molecule/nexus_common_test_vars.yml
@@ -80,6 +80,13 @@ nexus_repos_maven_group:
       - jboss
     layout_policy: permissive
     version_policy: mixed
+  - name: public-offline
+    online: false
+    member_repos:
+      - central
+      - jboss
+    layout_policy: permissive
+    version_policy: mixed
 
 nexus_repos_npm_hosted: []
 nexus_repos_npm_group:


### PR DESCRIPTION
fixes #290

Looked like a simple change. Worked as expected on rockylinux9 during local dev/test cycle.