### PR TITLE
Fix archive scripts permission and concurrency problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,17 @@ the role. It can be used later in your playbook if needed (e.g. for an upgrade n
 Directory on target where the nexus package will be downloaded.
 
 **Important note**: if you intend to run the role periodically to maintain/provision your nexus install, you should make
-sure the downloaded files will persists between run. On RHEL/Centos specifically, you should change this dir to a location that
-is not cleaned up automatically. If the package file does not persit, it will be downloaded again which might cause an unnecessary restart of nexus.
+sure the downloaded files will persist between run. On RHEL/Centos specifically, you should change this dir to a location that
+is not cleaned up automatically. If the package file does not persist, it will be downloaded again which might cause an unnecessary restart of nexus.
+
+### Local tmp dir on controller
+```yaml
+nexus_local_tmp_dir: /tmp
+```
+
+This directory is used to create a local archive of groovy script prior to sending them to the target.
+On shared ansible controller, you should modify this path to one you own (e.g. `/home/<user>/tmp`).
+**Important:** this directory **must** exist.
 
 ### Nexus port, context path and listening IP
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ nexus_version: ""
 # nexus_version_running: <unset>
 
 nexus_download_dir: /tmp
+nexus_local_tmp_dir: /tmp # On shared ansible controller, change this to a path you own (i.e. /home/<user>/tmp)
 nexus_download_url: https://download.sonatype.com/nexus/3
 nexus_download_retries: 0
 nexus_download_delay: 15

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -561,7 +561,7 @@
   become: false
   community.general.archive:
     path: "{{ role_path }}/files/groovy/*"
-    dest: /tmp/nexus-upload-groovy-scripts.tar.gz
+    dest: "{{ nexus_local_tmp_dir }}/nexus-upload-groovy-scripts.tar.gz"
     mode: "0644"
   check_mode: false
   run_once: true


### PR DESCRIPTION
Users on shared systems can encounter permission and/or concurrency
problems when groovy script are archived locally. This PR allows such
users to change the archive directory to a personnal tmp dir
rather that the system /tmp to avoid those issues.

Fixes #342
