### PR TITLE
Added Support for custom UID and GID for nexus user/group

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,10 +198,12 @@ your own proxy)
 ### Nexus OS user and group
 ```yaml
     nexus_os_group: 'nexus'
+    nexus_os_gid: 1000
     nexus_os_user: 'nexus'
+    nexus_os_uid: 1000
 ```
 
-User and group used to own the nexus files and run the service, those will be created by the role if absent.
+User and group used to own the nexus files and run the service, those will be created by the role if absent. If defined a uid and gid will be used apon creation.
 
 ```yaml
     nexus_os_user_home_dir: '/home/nexus'

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -86,6 +86,7 @@
 - name: Ensure Nexus o/s group exists
   ansible.builtin.group:
     name: "{{ nexus_os_group }}"
+    uid: "{{ nexus_os_gid | default(omit) }}"
     state: present
 
 - name: Ensure Nexus o/s user exists
@@ -94,6 +95,7 @@
     group: "{{ nexus_os_group }}"
     home: "{{ nexus_os_user_home_dir }}"
     shell: /bin/bash
+    uid: "{{ nexus_os_uid | default(omit) }}"
     state: present
 
 - name: Ensure Nexus installation directory exists


### PR DESCRIPTION
I am migrating en existing nexus, and want to be able to set uid and gid to match my storage uid and gid. That is why this small change would be very helpful to have in here