### PR TITLE
Parametrized non blocking systemd restart during the installation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ nexus_tmp_dir: "{{ (ansible_os_family == 'RedHat') | ternary('/var/nexus-tmp', '
 nexus_script_dir: "{{ nexus_installation_dir }}/nexus-{{ nexus_version }}/etc/scripts"
 nexus_plugin_urls: []
 nexus_onboarding_wizard: false
+nexus_install_systemd_no_block: true
 
 # These are the default values for JVM Ram
 # don't touch those unless you have read

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,7 +9,7 @@
   ansible.builtin.systemd:
     name: nexus.service
     state: restarted
-    no_block: true
+    no_block: "{{ nexus_install_systemd_no_block }}"
   listen: nexus-service-restart
   when: ansible_service_mgr == 'systemd'
 


### PR DESCRIPTION
Fix #402 

This PR makes configurable the `no_block` in the [handler](https://github.com/ansible-ThoTeam/nexus3-oss/blob/3ae7487a6e805c1efa81050e1a870aa0d2aadcdc/handlers/main.yml#L12)  when extra cautious is desired.