### PR TITLE
Update nexus_install.yml to accept both 200 and 304 status codes

### DIFF
--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -77,7 +77,8 @@
     mode: "0644"
   check_mode: false
   register: download_status
-  until: download_status.status_code == 200
+  until: >
+    (download_status.status_code == 200) or (download_status.status_code == 304)
   retries: "{{ nexus_download_retries }}"
   delay: "{{ nexus_download_delay }}"
   notify:


### PR DESCRIPTION
If file exists on destination node and is identical to remote source, the `get_url` module outputs `304` status code and therefore both `200` and `304` need to be in the conditional.

In the current state, if file exists on destination node it will try X times until statuscode `200` is returned, which will result in a failed state of the run whenever a `304` status code is returned.