### PR TITLE
Fix/cleanup policies

### DIFF
--- a/files/groovy/create_cleanup_policies_from_list.groovy
+++ b/files/groovy/create_cleanup_policies_from_list.groovy
@@ -42,7 +42,7 @@ parsed_args.each { currentPolicy ->
                             currentPolicy.format,
                             currentPolicy.criteria.lastBlobUpdated,
                             currentPolicy.criteria.lastDownloaded,
-                            currentPolicy.criteria.preRelease,
+                            // currentPolicy.criteria.preRelease,
                             currentPolicy.criteria.regexKey)
                 existingPolicy.setNotes(currentPolicy.notes)
                 existingPolicy.setCriteria(criteriaMap)
@@ -58,7 +58,7 @@ parsed_args.each { currentPolicy ->
                             currentPolicy.format,
                             currentPolicy.criteria.lastBlobUpdated,
                             currentPolicy.criteria.lastDownloaded,
-                            currentPolicy.criteria.preRelease,
+                            // currentPolicy.criteria.preRelease,
                             currentPolicy.criteria.regexKey)
 
             CleanupPolicy cleanupPolicy = cleanupPolicyStorage.newCleanupPolicy()
@@ -96,11 +96,11 @@ def Map<String, String> createCriteria(currentPolicy) {
     } else {
         criteriaMap.put(LAST_DOWNLOADED_KEY, asStringSeconds(currentPolicy.criteria.lastDownloaded))
     }
-    if ((currentPolicy.criteria.preRelease == null) || (currentPolicy.criteria.preRelease == "")) {
-        criteriaMap.remove(IS_PRERELEASE_KEY)
-    } else {
-        criteriaMap.put(IS_PRERELEASE_KEY, Boolean.toString(currentPolicy.criteria.preRelease == "PRERELEASES"))
-    }
+    // if ((currentPolicy.criteria.preRelease == null) || (currentPolicy.criteria.preRelease == "")) {
+    //     criteriaMap.remove(IS_PRERELEASE_KEY)
+    // } else {
+    //     criteriaMap.put(IS_PRERELEASE_KEY, Boolean.toString(currentPolicy.criteria.preRelease == "PRERELEASES"))
+    // }
     if ((currentPolicy.criteria.regexKey == null) || (currentPolicy.criteria.regexKey == "")) {
         criteriaMap.remove(REGEX_KEY)
     } else {
@@ -128,10 +128,10 @@ def Boolean isPolicyEqual(existingPolicy, currentPolicy) {
         && currentCriteria.containsKey(LAST_DOWNLOADED_KEY)
         && existingPolicy.getCriteria()[LAST_DOWNLOADED_KEY] == currentCriteria[LAST_DOWNLOADED_KEY]))
 
-    isequal &= (((! existingPolicy.getCriteria().containsKey(IS_PRERELEASE_KEY)) && (! currentCriteria.containsKey(IS_PRERELEASE_KEY)))
-    ||  (existingPolicy.getCriteria().containsKey(IS_PRERELEASE_KEY)
-        && currentCriteria.containsKey(IS_PRERELEASE_KEY)
-        && existingPolicy.getCriteria()[IS_PRERELEASE_KEY] == currentCriteria[IS_PRERELEASE_KEY]))
+    // isequal &= (((! existingPolicy.getCriteria().containsKey(IS_PRERELEASE_KEY)) && (! currentCriteria.containsKey(IS_PRERELEASE_KEY)))
+    // ||  (existingPolicy.getCriteria().containsKey(IS_PRERELEASE_KEY)
+    //     && currentCriteria.containsKey(IS_PRERELEASE_KEY)
+    //     && existingPolicy.getCriteria()[IS_PRERELEASE_KEY] == currentCriteria[IS_PRERELEASE_KEY]))
 
     isequal &= (((! existingPolicy.getCriteria().containsKey(REGEX_KEY)) && (! currentCriteria.containsKey(REGEX_KEY)))
     ||  (existingPolicy.getCriteria().containsKey(REGEX_KEY)

--- a/files/groovy/create_cleanup_policies_from_list.groovy
+++ b/files/groovy/create_cleanup_policies_from_list.groovy
@@ -7,10 +7,6 @@ import java.util.concurrent.TimeUnit
 
 import org.sonatype.nexus.cleanup.storage.CleanupPolicy
 import org.sonatype.nexus.cleanup.storage.CleanupPolicyStorage
-import static org.sonatype.nexus.repository.search.DefaultComponentMetadataProducer.IS_PRERELEASE_KEY
-import static org.sonatype.nexus.repository.search.DefaultComponentMetadataProducer.LAST_BLOB_UPDATED_KEY
-import static org.sonatype.nexus.repository.search.DefaultComponentMetadataProducer.LAST_DOWNLOADED_KEY
-import static org.sonatype.nexus.repository.search.DefaultComponentMetadataProducer.REGEX_KEY;
 
 
 CleanupPolicyStorage cleanupPolicyStorage = container.lookup(CleanupPolicyStorage.class.getName())


### PR DESCRIPTION
When using Postgres the class `DefaultComponentMetadataProducer` is not available.
This PR uses the accessible classes from `CleanupPolicyStorage` which will handle the routing to the proper implementation for OrientDB or Postgres.

fixes #408