### PR TITLE
Use new dedicated link for java > 8

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ nexus_tmp_dir: "{{ (ansible_os_family == 'RedHat') | ternary('/var/nexus-tmp', '
 nexus_script_dir: "{{ nexus_installation_dir }}/nexus-{{ nexus_version }}/etc/scripts"
 nexus_plugin_urls: []
 nexus_onboarding_wizard: false
+nexus_java_version: 8
 
 # These are the default values for JVM Ram
 # don't touch those unless you have read

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -64,7 +64,7 @@
 
 - name: Register nexus package name
   ansible.builtin.set_fact:
-    nexus_package: nexus-{{ nexus_version }}-unix.tar.gz
+    nexus_package: nexus-{{ nexus_version }}{{ (nexus_java_version > 8) | ternary('-java11', '-java8') }}-unix.tar.gz
 
 - name: Download nexus_package
   ansible.builtin.get_url:


### PR DESCRIPTION
Previously there was one link, officially for Java 8 but actually working for all Java versions >=8.

Now the default link does not work with java 11 (`nexus.vmoptions` are set for Java 8 and need editing), so the dedicated link for java 11 should be used when appropriate.