### PR TITLE
Fix regex when detecting installed versions

### DIFF
--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -15,7 +15,7 @@
     nexus_version_running: >-
       {{
         nexus_latest_link.stat.lnk_target
-        | regex_replace('^.*/nexus-(\d*\.\d*\.\d*-\d*)', '\1')
+        | regex_replace('^nexus-(\d*\.\d*\.\d*-\d*)', '\1')
       }}
   when:
     - nexus_latest_link.stat.exists | default(false)


### PR DESCRIPTION
nexus_latest_link.stat.lnk_target   contains only the filename, without path but the current regex assumes that the path is also present in the value.

This causes the version to be detected as "nexus-3.45.1-01" instead of "3.45.1-01" and failed later on when trying to download the file https://......./nexus-nexus-3.45.1-01-unix-tar.gz   instead of https://......./nexus-3.45.1-01-unix-tar.gz

This fixes #421 