### PR TITLE
Allow installation of java11 version of nexus

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,12 @@ Ansible variables, along with the default values (see `default/main.yml`) :
     nexus_download_url: "http://download.sonatype.com/nexus/3"
     # nexus_download_ssl_verify: <unset>
     # nexus_version_running: <unset>
+    # nexus_suffix: <unset>
 ```
 
 The role will install latest nexus available version by default. You may fix the version by setting
 the `nexus_version` variable. See available versions at https://www.sonatype.com/download-oss-sonatype.
+Starting with 3.67.0 you can set `nexus_suffix` to `java11` to install that version (instead of the default java8).
 When having a slow pull through proxy, a retry can be useful to prevent timeouts. You can add retries to the download by setting these variables:
 ```yaml
     nexus_download_retries: 3 # 0 by default

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -66,6 +66,14 @@
   ansible.builtin.set_fact:
     nexus_package: nexus-{{ nexus_version }}-unix.tar.gz
 
+- name: Register nexus package name
+  ansible.builtin.set_fact:
+    nexus_package: nexus-{{ nexus_version }}-{{ nexus_suffix }}-unix.tar.gz
+  when:
+    - nexus_suffix is defined
+    - nexus_suffix is not none
+    - nexus_suffix | length
+
 - name: Download nexus_package
   ansible.builtin.get_url:
     url: "{{ nexus_download_url }}/{{ nexus_package }}"


### PR DESCRIPTION
Add optional "nexus_suffix" variable.

Can be set to "java11" to fetch the java11 version instead of the default java8 version starting with 3.76.0

