### PR TITLE
Fix jvm.log folder name

### DIFF
--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -230,7 +230,7 @@
   ansible.builtin.lineinfile:
     dest: "{{ nexus_installation_dir }}/nexus-latest/bin/nexus.vmoptions"
     regexp: ^-XX:LogFile=.*
-    line: -XX:LogFile={{ nexus_data_dir }}log/jvm.log
+    line: -XX:LogFile={{ nexus_data_dir }}/log/jvm.log
   notify:
     - nexus-service-stop
 


### PR DESCRIPTION
There is a missing `/` in the task enabling `jvm.log` which lead to creating an additional folder (in my case `nexus3log/jvm.log`)