### PR TITLE
Bump default timeout for nexus download & expose config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,11 @@ Ansible variables, along with the default values (see `default/main.yml`) :
 
 The role will install latest nexus available version by default. You may fix the version by setting
 the `nexus_version` variable. See available versions at https://www.sonatype.com/download-oss-sonatype.
-When having a slow pull through proxy, a retry can be useful to prevent timeouts. You can add retries to the download by setting these variables:
+
+When having a slow pull through proxy, increasing the timeout and/or adding retries can be useful to prevent failures. 
+You can tweak the download config by setting these variables:
 ```yaml
+    nexus_download_timeout: 300 # 60 by default
     nexus_download_retries: 3 # 0 by default
     nexus_download_delay: 15
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ nexus_version: ""
 nexus_download_dir: /tmp
 nexus_local_tmp_dir: /tmp # On shared ansible controller, change this to a path you own (i.e. /home/<user>/tmp)
 nexus_download_url: https://download.sonatype.com/nexus/3
+nexus_download_timeout: 60 # 1 minute
 nexus_download_retries: 0
 nexus_download_delay: 15
 nexus_os_group: nexus

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -75,6 +75,7 @@
     owner: root
     group: root
     mode: "0644"
+    timeout: "{{ nexus_download_timeout }}"
   check_mode: false
   register: download_status
   until: download_status.status_code == 200


### PR DESCRIPTION
Fixes https://github.com/ansible-ThoTeam/nexus3-oss/issues/434

Allow 60 seconds to download the nexus package, and expose `nexus_download_timeout` so this can be configured further if people need. 