### PR TITLE
fix wrong config-check in create_repos_from_list

### DIFF
--- a/files/groovy/create_repos_from_list.groovy
+++ b/files/groovy/create_repos_from_list.groovy
@@ -33,7 +33,7 @@ private boolean configurationChanged(Configuration oldConfig, Configuration newC
             oldConfig.attributes.httpclient.authentication = null
         }
     }
-    return oldConfig.properties != newConfig.properties
+    return oldConfig.attributes != newConfig.attributes
 }
 
 


### PR DESCRIPTION
Replace properties with attributes, otherwise it will always detect a change, because properties is not in the map of the Configuration class