### PR TITLE
Update setup_ldap.groovy to be compatible with newer versions

### DIFF
--- a/files/groovy/setup_ldap.groovy
+++ b/files/groovy/setup_ldap.groovy
@@ -27,7 +27,11 @@ connection.setHost(new Connection.Host(Connection.Protocol.valueOf(parsed_args.p
 if (parsed_args.auth == "simple") {
     connection.setAuthScheme("simple")
     connection.setSystemUsername(parsed_args.username)
-    connection.setSystemPassword(parsed_args.password)
+    try {
+        connection.setSystemPassword(parsed_args.password)
+    } catch (MissingMethodException) {
+        connection.setRawSystemPassword(parsed_args.password)
+    }
 } else {
     connection.setAuthScheme("none")
 }


### PR DESCRIPTION
In newer Nexus versions it seems like setSystemPassword now needs a crypto.secrets.Secret as parameter. To have it working the old way, we need to use setRawSystemPassword